### PR TITLE
Add tests for npm package "codecoverage-tools"

### DIFF
--- a/Tests/L0.ts
+++ b/Tests/L0.ts
@@ -1,0 +1,23 @@
+import { codecoverageconstantsTests } from "./codecoverageconstantsTests";
+import { codecoveragefactoryTests } from "./codecoveragefactoryTests";
+import { codecoverageenablerTests } from "./codecoverageenablerTests";
+import { utilitiesTests } from "./utilitiesTests";
+import { jacocoantccenablerTests } from "./jacocoantccenablerTests";
+import { jacocogradleccenablerTests } from "./jacocogradleccenablerTests";
+import { jacocomavenccenablerTests } from "./jacocomavenccenablerTests";
+import { coberturaantccenablerTests } from "./coberturaantccenablerTests";
+import { coberturagradleccenablerTests } from "./coberturagradleccenablerTests";
+import { coberturamavenccenablerTests } from "./coberturamavenccenablerTests";
+
+describe("codecoverage-tools suite", function() {
+    describe("codecoverageconstants", codecoverageconstantsTests);
+    describe("codecoveragefactory", codecoveragefactoryTests);
+    describe("codecoverageenabler", codecoverageenablerTests);
+    describe("utilities", utilitiesTests);
+    describe("jacoco.ant.ccenabler", jacocoantccenablerTests);
+    describe("jacoco.gradle.ccenabler", jacocogradleccenablerTests);
+    describe("jacoco.maven.ccenabler", jacocomavenccenablerTests);
+    describe("cobertura.ant.ccenabler", coberturaantccenablerTests);
+    describe("cobertura.gradle.ccenabler", coberturagradleccenablerTests);
+    describe("cobertura.maven.ccenabler", coberturamavenccenablerTests);
+});

--- a/Tests/coberturaantccenablerTests.ts
+++ b/Tests/coberturaantccenablerTests.ts
@@ -1,0 +1,257 @@
+import * as assert from 'assert';
+import * as ccc from "../codecoverageconstants";
+import * as expectedResults from './data/expectedResults';
+import * as fakeData from "./data/fakeData";
+import * as path from "path";
+import * as Q from "q";
+import * as rewire from 'rewire';
+import * as sinon from 'sinon';
+import * as stubs from './data/stubs'
+import * as tl from 'azure-pipelines-task-lib/task';
+import * as util from "../utilities";
+
+export function coberturaantccenablerTests() {
+    const sandbox = sinon.createSandbox();
+    const coberturaantccenablerRewired = rewire('../cobertura/cobertura.ant.ccenabler');
+    const coberturaAntCodeCoverageEnablerClass = coberturaantccenablerRewired.__get__('CoberturaAntCodeCoverageEnabler')
+    const coberturaAntCodeCoverageEnablerInstance = new coberturaAntCodeCoverageEnablerClass();
+
+    before(() => {
+        // reset all fields of class to be able to stub them
+        coberturaAntCodeCoverageEnablerInstance.reportDir = null;
+        coberturaAntCodeCoverageEnablerInstance.reportbuildfile = null;
+        coberturaAntCodeCoverageEnablerInstance.classDirs = null;
+        coberturaAntCodeCoverageEnablerInstance.includeFilter = null;
+        coberturaAntCodeCoverageEnablerInstance.excludeFilter = null;
+        coberturaAntCodeCoverageEnablerInstance.sourceDirs = null;
+    });
+
+    after(() => {
+        sandbox.restore();
+    });
+
+    describe('function enableCodeCoverage', () => {
+        let extractFiltersStub, applyFilterPatternStub, isNullOrWhitespaceStub;
+
+        before(() => {
+            sandbox.stub(tl, "debug").callsFake();
+            sandbox.stub(tl, "setResourcePath").callsFake();
+            extractFiltersStub = sandbox.stub(coberturaAntCodeCoverageEnablerInstance, 'extractFilters').callsFake();
+            applyFilterPatternStub = sandbox.stub(coberturaAntCodeCoverageEnablerInstance, 'applyFilterPattern').callsFake();
+            sandbox.stub(coberturaAntCodeCoverageEnablerInstance, 'addCodeCoverageData').returns(Q.resolve(() => ([])));
+            sandbox.stub(util, 'readXmlFileAsDom').callsFake();
+            isNullOrWhitespaceStub = sandbox.stub(util, 'isNullOrWhitespace');
+        });
+
+        after(() => {
+            sandbox.restore();
+        });
+
+        afterEach(() => {
+            extractFiltersStub.reset();
+            applyFilterPatternStub.reset();
+            isNullOrWhitespaceStub.reset();
+        })
+
+        it('should set sourceDirs as \'.\' in case it\'s not specified', async () => {
+            isNullOrWhitespaceStub.returns(true);
+            extractFiltersStub.returns({
+                excludeFilter: 'excludeFilter',
+                includeFilter: 'includeFilter'
+            });
+            applyFilterPatternStub.returns([]);
+            await coberturaAntCodeCoverageEnablerInstance.enableCodeCoverage({
+                buildfile: null,
+                classfilter: null,
+                sourcedirectories: null,
+                classfilesdirectories: null
+            });
+            assert.strictEqual(coberturaAntCodeCoverageEnablerInstance.sourceDirs, '.');
+        });
+
+        it('should join result of applyFilterPattern function with comma', async () => {
+            isNullOrWhitespaceStub.returns(false);
+            extractFiltersStub.returns({
+                excludeFilter: 'excludeFilter',
+                includeFilter: 'includeFilter'
+            });
+            applyFilterPatternStub
+                .onFirstCall().returns(["first", "second"])
+                .onSecondCall().returns(["third", "fourth"]);
+            await coberturaAntCodeCoverageEnablerInstance.enableCodeCoverage({
+                buildfile: null,
+                classfilter: null,
+                sourcedirectories: null,
+                classfilesdirectories: null
+            });
+            assert.strictEqual(coberturaAntCodeCoverageEnablerInstance.excludeFilter, 'first,second');
+            assert.strictEqual(coberturaAntCodeCoverageEnablerInstance.includeFilter, 'third,fourth');
+        });
+    });
+
+    describe('function applyFilterPattern', () => {
+        let isNullOrWhitespaceStub;
+
+        before(() => {
+            sandbox.stub(tl, "debug").callsFake();
+            sandbox.stub(util, "trimToEmptyString").callsFake((value) => value);
+            isNullOrWhitespaceStub = sandbox.stub(util, "isNullOrWhitespace").callsFake();
+        });
+
+        after(() => {
+            sandbox.restore();
+        });
+
+        afterEach(() => {
+            isNullOrWhitespaceStub.reset();
+        })
+
+        it('should return empty array if filter is empty', () => {
+            isNullOrWhitespaceStub.returns(true);
+            const actual = coberturaAntCodeCoverageEnablerInstance.applyFilterPattern(fakeData.filtersWithNotAppliedFilterPattern);
+            assert.deepStrictEqual(actual, []);
+        });
+    
+        it('should return correct array of filters', () => {
+            isNullOrWhitespaceStub.returns(false);
+            const actual = coberturaAntCodeCoverageEnablerInstance.applyFilterPattern(fakeData.filtersWithNotAppliedFilterPattern);
+            assert.deepStrictEqual(actual, expectedResults.coberturaAntCorrectedAppliedFilterPatter);
+        });
+    });
+
+    describe('function getClassData', () => {
+        let classDirsStub, isNullOrWhitespaceStub;
+
+        before(() => {
+            classDirsStub = sandbox.stub(coberturaAntCodeCoverageEnablerInstance, 'classDirs').value(fakeData.classDirs);
+            sandbox.stub(coberturaAntCodeCoverageEnablerInstance, 'includeFilter').value(fakeData.includeFilterStringified);
+            sandbox.stub(coberturaAntCodeCoverageEnablerInstance, 'excludeFilter').value(fakeData.excludeFilterStringified);
+            isNullOrWhitespaceStub = sandbox.stub(util, 'isNullOrWhitespace');
+        });
+
+        afterEach(() => {
+            isNullOrWhitespaceStub.reset();
+        });
+
+        it('should return correct structure', () => {
+            isNullOrWhitespaceStub.returns(false);
+            const actual = coberturaAntCodeCoverageEnablerInstance.getClassData();
+            assert.strictEqual(actual, expectedResults.getClassDataResult)
+        });
+
+        it('should set classDirs as \'.\' in case it\'s null', () => {
+            isNullOrWhitespaceStub.returns(true);
+            const actual = coberturaAntCodeCoverageEnablerInstance.getClassData();
+            assert.strictEqual(actual, expectedResults.getClassDataResultWhenClassDirsEmpty)
+        });
+    });
+
+    describe('function addCodeCoverageData', () => {
+        before(() => {
+            sandbox.stub(tl, 'loc').callsFake(() => 'error');
+            sandbox.stub(ccc, 'coberturaAntReport').callsFake();
+            sandbox.stub(path, 'join').callsFake();
+            sandbox.stub(path, 'dirname').callsFake();
+            sandbox.stub(coberturaAntCodeCoverageEnablerInstance, 'addCodeCoverageNodes').resolves('addCodeCoverageNodes result');
+            sandbox.stub(coberturaAntCodeCoverageEnablerInstance, 'createReportFile').resolves('createReportFile result');
+        });
+
+        after(() => {
+            sandbox.restore();
+        });
+
+        it('should reject if build configuration is null', () => {
+            assert.rejects(coberturaAntCodeCoverageEnablerInstance.addCodeCoverageData(null));
+        });
+        
+        it('should reject if build configuration doesn\'t have project node', () => {
+            assert.rejects(coberturaAntCodeCoverageEnablerInstance.addCodeCoverageData(fakeData.cherioObjWithoutProjectNode));
+        });
+
+        it('should return array with coverage plugin data and report file', async () => {
+            const actual = await coberturaAntCodeCoverageEnablerInstance.addCodeCoverageData(fakeData.cherioObjWithProjectNode);
+            assert.deepStrictEqual(actual, expectedResults.addCodeCoverageDataCobertura);
+        });
+    });
+
+    describe('function addCodeCoverageNodes', () => {
+        let enableForkingStub;
+        
+        before(() => {
+            sandbox.stub(tl, 'debug').callsFake();
+            sandbox.stub(tl, 'loc').callsFake();
+            sandbox.stub(ccc, 'coberturaAntCoverageEnable').returns('\n    <coberturaAntCoverageEnable/>');
+            enableForkingStub = sandbox.stub(coberturaAntCodeCoverageEnablerInstance, 'enableForking').callsFake();
+            sandbox.stub(util, 'writeFile').callsFake();
+        });
+        
+        after(() => {
+            sandbox.restore();
+        });
+
+        it('should reject if project doesn\'t have target in build configuration', () => {
+            assert.rejects(coberturaAntCodeCoverageEnablerInstance.addCodeCoverageNodes(fakeData.cherioObjWithProjectNode));
+        });
+        
+        it('should prepend project with a configuration and enable forking for each target', async () => {
+            const config = fakeData.coberturaAntBuildConfigurationWithTarget;
+            await coberturaAntCodeCoverageEnablerInstance.addCodeCoverageNodes(config);
+            assert.deepStrictEqual(config.xml(), expectedResults.addCodeCoverageNodesCoberturaResult);
+            sinon.assert.callCount(enableForkingStub, 3);
+            enableForkingStub.resetHistory();
+        });
+    });
+
+    describe('function enableForking', () => {
+        before(() => {
+            sandbox.stub(path, 'dirname').callsFake();
+            sandbox.stub(path, 'join').callsFake();
+            sandbox.stub(ccc, 'coberturaAntProperties').returns(stubs.coberturaAntPropertiesConfiguration);
+            sandbox.stub(ccc, 'coberturaAntInstrumentedClasses').returns(stubs.coberturaAntInstrumentedClassesConfiguration);
+            sandbox.stub(ccc, 'coberturaAntClasspathRef').returns(stubs.coberturaAntClasspathRefConfiguration);
+            sandbox.stub(coberturaAntCodeCoverageEnablerInstance, 'getClassData').callsFake();
+            sandbox.stub(coberturaAntCodeCoverageEnablerInstance, 'enableForkOnTestNodes').callsFake();
+        });
+
+        after(() => {
+            sandbox.restore();
+        });
+
+        it('should return correct configuration if there is no node \'cobertura-instrument\'', () => {
+            const config = fakeData.enableForkingBuildConfigWithTargetConfig;
+            const targetNode = fakeData.enableForkingBuildConfigWithTargetNode;
+            coberturaAntCodeCoverageEnablerInstance.enableForking(config, targetNode);
+            assert.deepStrictEqual(config.xml(), expectedResults.enableForkingWithoutCoberturaInstrument);
+        });
+        
+        it('should return correct configuration if there is node \'cobertura-instrument\'', () => {
+            const config = fakeData.enableForkingBuildConfigWithTargetAndCoberturaConfig;
+            const targetNode = fakeData.enableForkingBuildConfigWithTargetAndCoberturaNode;
+            coberturaAntCodeCoverageEnablerInstance.enableForking(config, targetNode);
+            assert.deepStrictEqual(config.xml(), expectedResults.enableForkingWithCoberturaInstrument);
+        });
+        
+        it('shouldn\'t add anything if there is no at least one target', () => {
+            const config = fakeData.enableForkingBuildConfigWithoutTargetConfig;
+            const targetNode = fakeData.enableForkingBuildConfigWithoutTargetNode;
+            coberturaAntCodeCoverageEnablerInstance.enableForking(config, targetNode);
+            assert.deepStrictEqual(config.xml(), expectedResults.enableForkingWithoutTarget);
+        });
+        
+        it('should add \'debug\' attribute to \'javac\' if it exists', () => {
+            const config = fakeData.enableForkingBuildConfigWithJavacConfig;
+            const targetNode = fakeData.enableForkingBuildConfigWithJavacNode;
+            coberturaAntCodeCoverageEnablerInstance.enableForking(config, targetNode);
+            assert.deepStrictEqual(config.xml(), expectedResults.enableForkingWithJavac);
+        });
+    });
+
+    describe('function enableForkOnTestNodes', () => {
+        it('should enable fork on specified note', () => {
+            const node = fakeData.nodeToEnableFork;
+            coberturaAntCodeCoverageEnablerInstance.enableForkOnTestNodes(node);
+            assert.strictEqual(node.attribs['fork'], 'true');
+            assert.strictEqual(node.attribs['forkmode'], 'once');
+        })
+    });
+}

--- a/Tests/coberturagradleccenablerTests.ts
+++ b/Tests/coberturagradleccenablerTests.ts
@@ -81,7 +81,7 @@ export function coberturagradleccenablerTests() {
                     gradle5xOrHigher: 'true'
                 });
             sandbox.assert.calledOnce(ccc.coberturaGradleMultiModuleEnable);
-            assert.strictEqual(actual, true);
+            assert.strictEqual(actual, '');
         });
 
         it('should call \'coberturaGradleSingleModuleEnable\' if project is single-module', async () => {
@@ -96,7 +96,7 @@ export function coberturagradleccenablerTests() {
                     gradle5xOrHigher: 'true'
                 });
             sandbox.assert.calledOnce(ccc.coberturaGradleSingleModuleEnable);
-            assert.strictEqual(actual, true);
+            assert.strictEqual(actual, '');
         });
 
         it('should reject promise in case of error', async () => {

--- a/Tests/coberturagradleccenablerTests.ts
+++ b/Tests/coberturagradleccenablerTests.ts
@@ -1,0 +1,117 @@
+import * as assert from 'assert';
+import * as ccc from "../codecoverageconstants";
+import * as expectedResults from "./data/expectedResults";
+import * as fakeData from "./data/fakeData"
+import * as rewire from 'rewire';
+import * as sinon from 'sinon';
+import * as tl from 'azure-pipelines-task-lib/task';
+import * as util from "../utilities";
+
+export function coberturagradleccenablerTests() {
+    const sandbox = sinon.createSandbox();
+    const coberturagradleenablerRewired = rewire('../cobertura/cobertura.gradle.ccenabler');
+    const coberturaGradleCodeCoverageEnablerClass = coberturagradleenablerRewired.__get__('CoberturaGradleCodeCoverageEnabler')
+    const coberturaGradleCodeCoverageEnablerInstance = new coberturaGradleCodeCoverageEnablerClass();
+
+    describe('function applyFilterPattern', () => {
+        let isNullOrWhitespaceStub;
+
+        before(() => {
+            sandbox.stub(tl, "debug").callsFake();
+            sandbox.stub(util, "trimToEmptyString").callsFake((value) => value);
+            isNullOrWhitespaceStub = sandbox.stub(util, "isNullOrWhitespace").callsFake();
+        });
+    
+        after(() => {
+            sandbox.restore();
+        });
+
+        afterEach(() => {
+            isNullOrWhitespaceStub.reset();
+        })
+
+        it('should return empty array if filter is empty', () => {
+            isNullOrWhitespaceStub.returns(true);
+            const actual = coberturaGradleCodeCoverageEnablerInstance.applyFilterPattern(fakeData.filtersWithNotAppliedFilterPattern);
+            assert.deepStrictEqual(actual, []);
+        });
+    
+        it('should return correct array of filters', () => {
+            isNullOrWhitespaceStub.returns(false);
+            const actual = coberturaGradleCodeCoverageEnablerInstance.applyFilterPattern(fakeData.filtersWithNotAppliedFilterPattern);
+            assert.deepStrictEqual(actual, expectedResults.coberturaGradleCorrectedAppliedFilterPatter);
+        });
+    });
+
+    describe('function enableCodeCoverage', () => {
+        let insertTextToFileSyncStub;
+
+        before(() => {
+            sandbox.stub(tl, "debug").callsFake();
+            sandbox.stub(tl, "warning").callsFake();
+            sandbox.stub(tl, "loc").callsFake();
+            sandbox.stub(coberturaGradleCodeCoverageEnablerInstance, "extractFilters").returns(fakeData.filters);
+            sandbox.stub(coberturaGradleCodeCoverageEnablerInstance, "applyFilterPattern")
+                .onCall(0)
+                .returns(fakeData.excludeFilter)
+                .onCall(1)
+                .returns(fakeData.includeFilter);
+            sandbox.stub(ccc, "coberturaGradleMultiModuleEnable").returns('Multi-Module Configuration');
+            sandbox.stub(ccc, "coberturaGradleSingleModuleEnable").returns('Single-MOdule Configuration');
+            insertTextToFileSyncStub = sandbox.stub(util, "insertTextToFileSync").callsFake();
+        });
+    
+        after(() => {
+            sandbox.restore();
+        });
+
+        afterEach(() => {
+            sandbox.resetHistory();
+        })
+
+        it('should call \'coberturaGradleMultiModuleEnable\' if project is multi-module', async () => {
+            const actual = await coberturaGradleCodeCoverageEnablerInstance.enableCodeCoverage(
+                {
+                    buildfile: fakeData.buildFile,
+                    classfilter: fakeData.classFilter,
+                    classfilesdirectories: fakeData.classDir,
+                    summaryfile: fakeData.summaryFile,
+                    reportdirectory: fakeData.reportDir,
+                    ismultimodule: 'true',
+                    gradle5xOrHigher: 'true'
+                });
+            sandbox.assert.calledOnce(ccc.coberturaGradleMultiModuleEnable);
+            assert.strictEqual(actual, true);
+        });
+
+        it('should call \'coberturaGradleSingleModuleEnable\' if project is single-module', async () => {
+            const actual = await coberturaGradleCodeCoverageEnablerInstance.enableCodeCoverage(
+                {
+                    buildfile: fakeData.buildFile,
+                    classfilter: fakeData.classFilter,
+                    classfilesdirectories: fakeData.classDir,
+                    summaryfile: fakeData.summaryFile,
+                    reportdirectory: fakeData.reportDir,
+                    ismultimodule: 'false',
+                    gradle5xOrHigher: 'true'
+                });
+            sandbox.assert.calledOnce(ccc.coberturaGradleSingleModuleEnable);
+            assert.strictEqual(actual, true);
+        });
+
+        it('should reject promise in case of error', async () => {
+            insertTextToFileSyncStub.callsFake(() => { throw new Error('Some error has occurred') });
+            assert.rejects(coberturaGradleCodeCoverageEnablerInstance.enableCodeCoverage(
+                {
+                    buildfile: fakeData.buildFile,
+                    classfilter: fakeData.classFilter,
+                    classfilesdirectories: fakeData.classDir,
+                    summaryfile: fakeData.summaryFile,
+                    reportdirectory: fakeData.reportDir,
+                    ismultimodule: 'false',
+                    gradle5xOrHigher: 'true'
+                }), Error);
+            insertTextToFileSyncStub.callsFake();
+        });
+    })
+}

--- a/Tests/coberturamavenccenablerTests.ts
+++ b/Tests/coberturamavenccenablerTests.ts
@@ -1,0 +1,226 @@
+import * as assert from 'assert';
+import * as ccc from "../codecoverageconstants";
+import * as expectedResults from "./data/expectedResults";
+import * as fakeData from "./data/fakeData";
+import * as Q from "q";
+import * as rewire from 'rewire';
+import * as sinon from 'sinon';
+import * as tl from 'azure-pipelines-task-lib/task';
+import * as util from "../utilities";
+
+export function coberturamavenccenablerTests() {
+    const sandbox = sinon.createSandbox();
+    const coberturamavenenablerRewired = rewire('../cobertura/cobertura.maven.ccenabler');
+    const coberturaMavenCodeCoverageEnablerClass = coberturamavenenablerRewired.__get__('CoberturaMavenCodeCoverageEnabler')
+    const coberturaMavenCodeCoverageEnablerInstance = new coberturaMavenCodeCoverageEnablerClass();
+
+    before(() => {
+        coberturaMavenCodeCoverageEnablerInstance.includeFilter = null;
+        coberturaMavenCodeCoverageEnablerInstance.excludeFilter = null;
+    });
+    
+    after(() => {
+        sandbox.restore();
+    });
+    
+    describe('function enableCodeCoverage', () => {
+        let extractFiltersStub, applyFilterPatternStub, readXmlFileAsJsonStub
+        
+        before(() => {
+            sandbox.stub(tl, 'debug');
+            extractFiltersStub = sandbox.stub(coberturaMavenCodeCoverageEnablerInstance, 'extractFilters').returns(fakeData.filters);
+            applyFilterPatternStub = sandbox.stub(coberturaMavenCodeCoverageEnablerInstance, 'applyFilterPattern').callsFake();
+            sandbox.stub(coberturaMavenCodeCoverageEnablerInstance, 'addCodeCoveragePluginData').returns(Q.resolve());
+            readXmlFileAsJsonStub = sandbox.stub(util, 'readXmlFileAsJson').returns(Q.resolve());
+        });
+        
+        afterEach(() => {
+            applyFilterPatternStub.reset();
+            readXmlFileAsJsonStub.reset();
+        });
+        
+        after(() => {
+            sandbox.restore();
+            coberturaMavenCodeCoverageEnablerInstance.includeFilter = null;
+            coberturaMavenCodeCoverageEnablerInstance.excludeFilter = null;
+        });
+        
+        it('should join filters and call correct functions', async () => {
+            applyFilterPatternStub
+                .onFirstCall().returns(fakeData.excludeFilter)
+                .onSecondCall().returns(fakeData.includeFilter);
+            await coberturaMavenCodeCoverageEnablerInstance.enableCodeCoverage({
+                buildfile: fakeData.buildFile,
+                classfilter: fakeData.classFilter
+            });
+            assert.strictEqual(coberturaMavenCodeCoverageEnablerInstance.includeFilter, fakeData.includeFilterStringifiedWithComma);
+            assert.strictEqual(coberturaMavenCodeCoverageEnablerInstance.excludeFilter, fakeData.excludeFilterStringifiedWithComma);
+            sinon.assert.calledOnceWithExactly(extractFiltersStub, fakeData.classFilter);
+            sinon.assert.calledWithExactly(applyFilterPatternStub, fakeData.filters.includeFilter);
+            sinon.assert.calledWithExactly(applyFilterPatternStub, fakeData.filters.excludeFilter);
+            sinon.assert.calledOnceWithExactly(readXmlFileAsJsonStub, fakeData.buildFile);
+        });
+    });
+    
+    describe('function applyFilterPattern', () => {
+        let isNullOrWhitespaceStub;
+
+        before(() => {
+            sandbox.stub(tl, 'debug');
+            sandbox.stub(util, "trimToEmptyString").callsFake((value) => value);
+            isNullOrWhitespaceStub = sandbox.stub(util, "isNullOrWhitespace").callsFake();
+        });
+    
+        after(() => {
+            sandbox.restore();
+        });
+
+        afterEach(() => {
+            isNullOrWhitespaceStub.reset();
+        })
+
+        it('should return empty array if filter is empty', () => {
+            isNullOrWhitespaceStub.returns(true);
+            const actual = coberturaMavenCodeCoverageEnablerInstance.applyFilterPattern("");
+            assert.deepStrictEqual(actual, []);
+        });
+    
+        it('should return correct array of filters', () => {
+            isNullOrWhitespaceStub.returns(false);
+            const actual = coberturaMavenCodeCoverageEnablerInstance.applyFilterPattern(fakeData.filtersWithNotAppliedFilterPattern);
+            assert.deepStrictEqual(actual, expectedResults.coberturaMavenCorrectedAppliedFilterPatter);
+        });
+    });
+    
+    describe('function getBuildDataNode', () => {
+        it('should return correct build node and correct build configuration if build node is string', () => {
+            const config = fakeData.getBuildDataNodeBuildJsonContentBuildString();
+            const actual = coberturaMavenCodeCoverageEnablerInstance.getBuildDataNode(config);
+            assert.deepStrictEqual(actual, expectedResults.getBuildDataNodeBuildString);
+            assert.deepStrictEqual(config, expectedResults.getBuildDataNodeBuildJsonContentBuildString);
+        });
+        
+        it('should return correct build node if build node is array', () => {
+            const config = fakeData.getBuildDataNodeBuildJsonContentBuildArray();
+            const actual = coberturaMavenCodeCoverageEnablerInstance.getBuildDataNode(config);
+            assert.deepStrictEqual(actual, expectedResults.getBuildDataNodeBuildArray);
+            assert.deepStrictEqual(config, expectedResults.getBuildDataNodeBuildJsonContentBuildArray);
+        });
+        
+        it('should return correct build node and correct build configuration if build node is array with string element', () => {
+            const config = fakeData.getBuildDataNodeBuildJsonContentBuildArrayWithStringElement();
+            const actual = coberturaMavenCodeCoverageEnablerInstance.getBuildDataNode(config);
+            assert.deepStrictEqual(actual, expectedResults.getBuildDataNodeBuildArrayWithStringElement);
+            assert.deepStrictEqual(config, expectedResults.getBuildDataNodeBuildJsonContentBuildArrayWithStringElement);
+        });
+    });
+    
+    describe('function getPluginDataNode ', () => {
+        it('should return correct plugin data node if there is no plugin data node', () => {
+            const config = fakeData.getPluginDataNodeWithoutPluginsNode();
+            const actual = coberturaMavenCodeCoverageEnablerInstance.getPluginDataNode(config);
+            assert.deepStrictEqual(actual, expectedResults.getPluginDataNodeWithoutPluginsNode);
+            assert.deepStrictEqual(config, expectedResults.getPluginDataNodeWithoutPluginsNodeConfig);
+        });
+        
+        it('should return correct plugin data node if there is plugin node with string value', () => {
+            const config = fakeData.getPluginDataNodePluginsString();
+            const actual = coberturaMavenCodeCoverageEnablerInstance.getPluginDataNode(config);
+            assert.deepStrictEqual(actual, expectedResults.getPluginDataNodePluginsString);
+            assert.deepStrictEqual(config, expectedResults.getPluginDataNodePluginsStringConfig);
+        });
+        
+        it('should return correct plugin data node if there is plugin node with string array', () => {
+            const config = fakeData.getPluginDataNodePluginsStringArray();
+            const actual = coberturaMavenCodeCoverageEnablerInstance.getPluginDataNode(config);
+            assert.deepStrictEqual(actual, expectedResults.getPluginDataNodePluginsStringArray);
+            assert.deepStrictEqual(config, expectedResults.getPluginDataNodePluginsStringArrayConfig);
+        });
+        
+        it('should return correct plugin data node if there is plugin node with array', () => {
+            const config = fakeData.getPluginDataNodePluginsArray();
+            const actual = coberturaMavenCodeCoverageEnablerInstance.getPluginDataNode(config);
+            assert.deepStrictEqual(actual, expectedResults.getPluginDataNodePluginsArray);
+            assert.deepStrictEqual(config, expectedResults.getPluginDataNodePluginsArrayConfig);
+        });
+        
+        it('should return correct plugin data node if there is plugin node contains object', () => {
+            const config = fakeData.getPluginDataNodePluginsAnother();
+            const actual = coberturaMavenCodeCoverageEnablerInstance.getPluginDataNode(config);
+            assert.deepStrictEqual(actual, expectedResults.getPluginDataNodePluginsAnother);
+            assert.deepStrictEqual(config, expectedResults.getPluginDataNodePluginsAnotherConfig);
+        });
+    });
+    
+    describe('function getReportingPluginNode', () => {
+        it('should return null if reportNode is null', () => {
+            const config = null;
+            const actual = coberturaMavenCodeCoverageEnablerInstance.getReportingPluginNode(config);
+            assert.deepStrictEqual(actual, undefined);
+        });
+        
+        it('should return null if reportNode is string', () => {
+            const config = fakeData.getReportingPluginNodeString();
+            const actual = coberturaMavenCodeCoverageEnablerInstance.getReportingPluginNode(config);
+            assert.deepStrictEqual(actual, undefined);
+        });
+        
+        it('should return correct plugin node if reportNode is array', () => {
+            const config = fakeData.getReportingPluginNodeArray();
+            const actual = coberturaMavenCodeCoverageEnablerInstance.getReportingPluginNode(config);
+            assert.deepStrictEqual(actual, expectedResults.getReportingPluginNodeArray);
+        });
+        
+        it('should return correct plugin node if reportNode is an object', () => {
+            const config = fakeData.getReportingPluginNodeAnother();
+            const actual = coberturaMavenCodeCoverageEnablerInstance.getReportingPluginNode(config);
+            assert.deepStrictEqual(actual, expectedResults.getReportingPluginNodeAnother);
+        });
+    });
+    
+    describe('function addCodeCoverageNodes', () => {
+        let coberturaMavenEnableStub, addPropToJsonStub;
+        
+        before(() => {
+            sandbox.stub(tl, 'debug');
+            sandbox.stub(tl, 'loc');
+            sandbox.stub(coberturaMavenCodeCoverageEnablerInstance, 'includeFilter').value(fakeData.includeFilterStringified);
+            sandbox.stub(coberturaMavenCodeCoverageEnablerInstance, 'excludeFilter').value(fakeData.excludeFilterStringified);
+            sandbox.stub(coberturaMavenCodeCoverageEnablerInstance, 'getBuildDataNode');
+            sandbox.stub(coberturaMavenCodeCoverageEnablerInstance, 'getPluginDataNode').returns('getPluginDataNode');
+            sandbox.stub(coberturaMavenCodeCoverageEnablerInstance, 'getReportingPluginNode').returns('getReportingPluginNode');
+            coberturaMavenEnableStub = sandbox.stub(ccc, 'coberturaMavenEnable').returns(Q.resolve({plugin: 'coberturaMavenEnable'}));
+            sandbox.stub(ccc, 'coberturaMavenReport').returns(Q.resolve({plugin: 'coberturaMavenReport'}));
+            addPropToJsonStub = sandbox.stub(util, 'addPropToJson');
+        });
+        
+        after(() => {
+            sandbox.restore();
+        })
+        
+        afterEach(() => {
+            addPropToJsonStub.resetHistory();
+            coberturaMavenEnableStub.resetHistory();
+        });
+        
+        it('should reject promise if there is no node \'project\' in build configuration', () => {
+            assert.rejects(coberturaMavenCodeCoverageEnablerInstance.addCodeCoverageNodes(fakeData.addCodeCoverageNodesWithoutProject));
+        });
+        
+        it('should call correct functions if project is single-module', async () => {
+            const actual = await coberturaMavenCodeCoverageEnablerInstance.addCodeCoverageNodes(fakeData.addCodeCoverageNodesSingleProjectWithBuildNode());
+            assert.deepStrictEqual(actual, expectedResults.addCodeCoverageNodesSingleModule);
+            sinon.assert.calledOnceWithExactly(coberturaMavenEnableStub, fakeData.includeFilterStringified, fakeData.excludeFilterStringified, 'false');
+            sinon.assert.calledWithExactly(addPropToJsonStub, 'getPluginDataNode', "plugin", 'coberturaMavenEnable');
+            sinon.assert.calledWithExactly(addPropToJsonStub, 'getReportingPluginNode', "plugin", 'coberturaMavenReport'); 
+        });
+        
+        it('should call correct functions if project is multi-module', async () => {
+            const actual = await coberturaMavenCodeCoverageEnablerInstance.addCodeCoverageNodes(fakeData.addCodeCoverageNodesMultiProject());
+            assert.deepStrictEqual(actual, expectedResults.addCodeCoverageNodesMultiModule);
+            sinon.assert.calledOnceWithExactly(coberturaMavenEnableStub, fakeData.includeFilterStringified, fakeData.excludeFilterStringified, 'true');
+            sinon.assert.calledWithExactly(addPropToJsonStub, 'getPluginDataNode', "plugin", 'coberturaMavenEnable');
+            sinon.assert.calledWithExactly(addPropToJsonStub, 'getReportingPluginNode', "plugin", 'coberturaMavenReport'); 
+        });
+    });
+}

--- a/Tests/codecoverageconstantsTests.ts
+++ b/Tests/codecoverageconstantsTests.ts
@@ -80,13 +80,22 @@ export function codecoverageconstantsTests() {
             assert.strictEqual(actual, expectedResults.coberturaGradleMultiModuleWithNotSpecifiedClassDir);
         });
 
-        it('function jacocoMavenPluginEnable  should return correct configuration', () => {
+        it('function jacocoMavenPluginEnable should return correct configuration', () => {
             const actual = codecoverageconstantsRewire.jacocoMavenPluginEnable(fakeData.includeFilter, fakeData.excludeFilter, fakeData.reportDir);
             assert.deepStrictEqual(actual, expectedResults.jacocoMavenSingleProject);
         });
 
         it('function jacocoMavenMultiModuleReport should return correct configuration', () => {
-            const actual = codecoverageconstantsRewire.jacocoMavenMultiModuleReport(fakeData.reportDir, fakeData.sourceDirs, fakeData.classDirs, fakeData.includeFilterStringified, fakeData.excludeFilterStringified);
+            const actual = codecoverageconstantsRewire.jacocoMavenMultiModuleReport(
+                fakeData.reportArtifactId,
+                fakeData.sourceDirs,
+                fakeData.classDirs,
+                fakeData.includeFilterStringified,
+                fakeData.excludeFilterStringified,
+                fakeData.groupId,
+                fakeData.formattedParentData,
+                fakeData.modules);
+            
             assert.strictEqual(actual, expectedResults.jacocoMavenMultiProject);
         });
 

--- a/Tests/codecoverageconstantsTests.ts
+++ b/Tests/codecoverageconstantsTests.ts
@@ -1,0 +1,130 @@
+import * as assert from 'assert';
+import * as rewire from 'rewire';
+import * as sinon from 'sinon';
+import * as util from "../utilities";
+
+import * as stubs from './data/stubs';
+import * as fakeData from './data/fakeData';
+import * as expectedResults from './data/expectedResults';
+
+const codecoverageconstantsRewire = rewire('../codecoverageconstants');
+const getFormattedFileCollectionAssignGradle = codecoverageconstantsRewire.__get__('getFormattedFileCollectionAssignGradle');
+
+export function codecoverageconstantsTests() {
+    describe('function getFormattedFileCollectionAssignGradle', () => {
+        it ('should return syntax for Gradle < 5.x', () => {
+            const property = 'testProperty';
+            
+            const expected = `${property} =`
+            const actual = getFormattedFileCollectionAssignGradle(property, false);
+    
+            assert.strictEqual(actual, expected);
+        })
+    
+        it ('should return syntax for Gradle >= 5.x', () => {
+            const property = 'testProperty';
+            
+            const expected = `${property}.setFrom`
+            const actual = getFormattedFileCollectionAssignGradle(property, true);
+    
+            assert.strictEqual(actual, expected);
+        })    
+    });
+
+    describe('functions related to build script configuration', () => {
+        before(() => {
+            codecoverageconstantsRewire.__set__('getFormattedFileCollectionAssignGradle', stubs.getFormattedFileCollectionAssignGradleOutput);
+        });
+
+        after(() => {
+            codecoverageconstantsRewire.__set__('getFormattedFileCollectionAssignGradle', getFormattedFileCollectionAssignGradle);
+        });
+
+        it('function jacocoGradleSingleModuleEnable should return correct configuration', () => {
+            const actual = codecoverageconstantsRewire.jacocoGradleSingleModuleEnable(fakeData.excludeFilterStringified, fakeData.includeFilterStringified, fakeData.classDir, fakeData.reportDir, false);
+            assert.strictEqual(actual, expectedResults.jacocoGradleSingleModule);
+        });
+
+        it('function jacocoGradleMultiModuleEnable should return correct configuration', () => {
+            const actual = codecoverageconstantsRewire.jacocoGradleMultiModuleEnable(fakeData.excludeFilterStringified, fakeData.includeFilterStringified, fakeData.classDir, fakeData.reportDir, false);
+            assert.strictEqual(actual, expectedResults.jacocoGradleMultiModule);
+        });
+
+        it('function coberturaGradleSingleModuleEnable should return correct configuration', () => {
+            const actual = codecoverageconstantsRewire.coberturaGradleSingleModuleEnable(fakeData.excludeFilterStringified, fakeData.includeFilterStringified, fakeData.classDir, fakeData.sourceDir, fakeData.reportDir);
+            assert.strictEqual(actual, expectedResults.coberturaGradleSingleModule);
+        });
+
+        it('function coberturaGradleSingleModuleEnable should return correct configuration if source dir is not specified', () => {
+            const actual = codecoverageconstantsRewire.coberturaGradleSingleModuleEnable(fakeData.excludeFilterStringified, fakeData.includeFilterStringified, fakeData.classDir, null, fakeData.reportDir);
+            assert.strictEqual(actual, expectedResults.coberturaGradleSingleModuleWithNotSpecifiedSourceDir);
+        });
+
+        it('function coberturaGradleSingleModuleEnable should return correct configuration if class dir is not specified', () => {
+            const actual = codecoverageconstantsRewire.coberturaGradleSingleModuleEnable(fakeData.excludeFilterStringified, fakeData.includeFilterStringified, null, fakeData.sourceDir, fakeData.reportDir);
+            assert.strictEqual(actual, expectedResults.coberturaGradleSingleModuleWithNotSpecifiedClassDir);
+        });
+
+        it('function coberturaGradleMultiModuleEnable should return correct configuration', () => {
+            const actual = codecoverageconstantsRewire.coberturaGradleMultiModuleEnable(fakeData.excludeFilterStringified, fakeData.includeFilterStringified, fakeData.classDir, fakeData.sourceDir, fakeData.reportDir);
+            assert.strictEqual(actual, expectedResults.coberturaGradleMultiModule);
+        });
+
+        it('function coberturaGradleMultiModuleEnable should return correct configuration if source dir is not specified', () => {
+            const actual = codecoverageconstantsRewire.coberturaGradleMultiModuleEnable(fakeData.excludeFilterStringified, fakeData.includeFilterStringified, fakeData.classDir, null, fakeData.reportDir);
+            assert.strictEqual(actual, expectedResults.coberturaGradleMultiModuleWithNotSpecifiedSourceDir);
+        });
+
+        it('function coberturaGradleMultiModuleEnable should return correct configuration if class dir is not specified', () => {
+            const actual = codecoverageconstantsRewire.coberturaGradleMultiModuleEnable(fakeData.excludeFilterStringified, fakeData.includeFilterStringified, null, fakeData.sourceDir, fakeData.reportDir);
+            assert.strictEqual(actual, expectedResults.coberturaGradleMultiModuleWithNotSpecifiedClassDir);
+        });
+
+        it('function jacocoMavenPluginEnable  should return correct configuration', () => {
+            const actual = codecoverageconstantsRewire.jacocoMavenPluginEnable(fakeData.includeFilter, fakeData.excludeFilter, fakeData.reportDir);
+            assert.deepStrictEqual(actual, expectedResults.jacocoMavenSingleProject);
+        });
+
+        it('function jacocoMavenMultiModuleReport should return correct configuration', () => {
+            const actual = codecoverageconstantsRewire.jacocoMavenMultiModuleReport(fakeData.reportDir, fakeData.sourceDirs, fakeData.classDirs, fakeData.includeFilterStringified, fakeData.excludeFilterStringified);
+            assert.strictEqual(actual, expectedResults.jacocoMavenMultiProject);
+        });
+
+        it('function coberturaMavenEnable should call \'util.convertXmlStringToJson\' once with correct parameters', async () => {
+            const convertXmlStringToJsonStub = sinon.stub(util, "convertXmlStringToJson").callsFake();
+            codecoverageconstantsRewire.coberturaMavenEnable(fakeData.includeFilterStringified, fakeData.excludeFilterStringified, fakeData.aggregate);
+            sinon.assert.calledOnceWithExactly(convertXmlStringToJsonStub, expectedResults.coberturaMavenEnableConfiguration);
+            convertXmlStringToJsonStub.restore();
+        });
+
+        it('function jacocoAntReport should return correct configuration', () => {
+            const actual = codecoverageconstantsRewire.jacocoAntReport(fakeData.reportDir, fakeData.classDir, fakeData.sourceDir);
+            assert.strictEqual(actual, expectedResults.jacocoAntReportConfiguration);
+        });
+
+        it('function jacocoAntReport should return correct configuration', () => {
+            const actual = codecoverageconstantsRewire.jacocoAntReport(fakeData.reportDir, fakeData.classDir, fakeData.sourceDir);
+            assert.strictEqual(actual, expectedResults.jacocoAntReportConfiguration);
+        });
+
+        it('function jacocoAntCoverageEnable should return correct configuration', () => {
+            const actual = codecoverageconstantsRewire.jacocoAntCoverageEnable(fakeData.reportDir);
+            assert.deepStrictEqual(actual, expectedResults.jacocoAntCoverageEnableConfiguration);
+        });
+
+        it('function coberturaAntReport should return correct configuration', () => {
+            const actual = codecoverageconstantsRewire.coberturaAntReport(fakeData.sourceDir, fakeData.reportDir);
+            assert.deepStrictEqual(actual, expectedResults.coberturaAntReportConfiguration);
+        });
+
+        it('function coberturaAntInstrumentedClasses should return correct configuration', () => {
+            const actual = codecoverageconstantsRewire.coberturaAntInstrumentedClasses(fakeData.baseDir, fakeData.reportDir, fakeData.classDir);
+            assert.deepStrictEqual(actual, expectedResults.coberturaAntInstrumentedClassesConfiguration);
+        });
+
+        it('function coberturaAntProperties should return correct configuration', () => {
+            const actual = codecoverageconstantsRewire.coberturaAntProperties(fakeData.reportDir, fakeData.baseDir);
+            assert.deepStrictEqual(actual, expectedResults.coberturaAntPropertiesConfiguration);
+        });
+    });
+}

--- a/Tests/codecoverageenablerTests.ts
+++ b/Tests/codecoverageenablerTests.ts
@@ -1,0 +1,61 @@
+import * as assert from 'assert';
+import * as rewire from 'rewire';
+import * as sinon from 'sinon';
+import * as tl from 'azure-pipelines-task-lib/task';
+import * as util from "../utilities";
+
+import * as expectedResults from './data/expectedResults';
+import * as fakeData from './data/fakeData';
+
+export function codecoverageenablerTests() {
+    const sandbox = sinon.createSandbox();
+    let isNullOrWhitespaceStub;
+
+    before(() => {
+        sandbox.stub(tl, "debug").callsFake();
+        isNullOrWhitespaceStub = sandbox.stub(util, "isNullOrWhitespace").callsFake();
+    });
+
+    after(() => {
+        sandbox.restore();
+    });
+
+    describe('class CodeCoverageEnabler', () => {
+        const codecoverageenablerRewired = rewire('../codecoverageenabler');
+        const codeCoverageEnablerClass = codecoverageenablerRewired.__get__('CodeCoverageEnabler')
+        const codeCoverageEnablerTestClass = new codeCoverageEnablerClass();
+
+        afterEach(() => {
+            isNullOrWhitespaceStub.reset();
+        })
+
+        it('function extractFilters should return empty filters when specified empty class filter', () => {
+            isNullOrWhitespaceStub.returns(true);
+            const actual = codeCoverageEnablerTestClass.extractFilters(fakeData.classFilter);
+            assert.deepStrictEqual(actual, expectedResults.emptyFilters);
+        });
+
+        it('function extractFilters should throw exception if class filter contains at least one empty filter', () => {
+            isNullOrWhitespaceStub
+                .onCall(0).returns(false)
+                .returns(true);
+            assert.throws(() => codeCoverageEnablerTestClass.extractFilters(fakeData.classFilter), Error);
+        });
+
+        it('function extractFilters should throw exception if class filter contains at least one filter with length < 2', () => {
+            isNullOrWhitespaceStub.returns(false);
+            assert.throws(() => codeCoverageEnablerTestClass.extractFilters(fakeData.invalidClassFilter1), Error);
+        });
+
+        it('function extractFilters should throw exception if class filter contains at least one unsupported prefix', () => {
+            isNullOrWhitespaceStub.returns(false);
+            assert.throws(() => codeCoverageEnablerTestClass.extractFilters(fakeData.invalidClassFilter2), Error);
+        });
+
+        it('function extractFilters should return correct class filters', () => {
+            isNullOrWhitespaceStub.returns(false);
+            const actual = codeCoverageEnablerTestClass.extractFilters(fakeData.classFilter);
+            assert.deepStrictEqual(actual, expectedResults.correctFilters);
+        });
+    });
+}

--- a/Tests/codecoveragefactoryTests.ts
+++ b/Tests/codecoveragefactoryTests.ts
@@ -1,0 +1,15 @@
+import assert = require("assert");
+import { CodeCoverageEnablerFactory } from "../codecoveragefactory";
+
+export function codecoveragefactoryTests() {
+
+    it('should throw exception if specified tool doesn\'t exist', function () {
+        const factory = new CodeCoverageEnablerFactory();
+        const buildTool = 'Not exist build tool';
+        const ccTool = 'Not exist code coverage tool';
+
+        assert.throws(
+            () => {factory.getTool(buildTool, ccTool)}, 
+            Error);
+    });
+}

--- a/Tests/data/expectedResults.ts
+++ b/Tests/data/expectedResults.ts
@@ -1,0 +1,699 @@
+import * as os from "os";
+
+export const jacocoGradleSingleModule = `
+allprojects {
+    repositories {
+        mavenCentral()
+    }
+
+    apply plugin: 'jacoco'
+}
+
+def jacocoExcludes = ['**/R.class','**/R$.class']
+def jacocoIncludes = ['**/*$ViewInjector.class','**/*$ViewBinder.class']
+
+jacocoTestReport {
+    doFirst {
+        fileCollectionAssign fileTree(dir: "some/folder/with/classes").exclude(jacocoExcludes).include(jacocoIncludes)
+    }
+
+    reports {
+        html.enabled = true
+        xml.enabled = true
+        xml.destination file("report/dir/summary.xml")
+        html.destination file("report/dir")
+    }
+}
+
+test {
+    finalizedBy jacocoTestReport
+    jacoco {
+        destinationFile = file("report/dir/jacoco.exec")
+    }
+}`;
+
+export const jacocoGradleMultiModule = `
+allprojects {
+    repositories {
+        mavenCentral()
+    }
+
+    apply plugin: 'jacoco'
+}
+
+def jacocoExcludes = ['**/R.class','**/R$.class']
+def jacocoIncludes = ['**/*$ViewInjector.class','**/*$ViewBinder.class']
+
+subprojects {
+    jacocoTestReport {
+        doFirst {
+            fileCollectionAssign fileTree(dir: "some/folder/with/classes").exclude(jacocoExcludes).include(jacocoIncludes)
+        }
+
+        reports {
+            html.enabled = true
+            html.destination file("\${buildDir}/jacocoHtml")
+            xml.enabled = true
+            xml.destination file("\${buildDir}/summary.xml")
+        }
+    }
+    test {
+        jacoco {
+            destinationFile = file("report/dir/jacoco.exec")
+        }
+    }
+}
+
+task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
+    dependsOn = subprojects.test
+    fileCollectionAssign files(subprojects.jacocoTestReport.executionData)
+    fileCollectionAssign files(subprojects.sourceSets.main.allSource.srcDirs)
+    fileCollectionAssign files()
+
+    doFirst {
+        subprojects.each {
+            if (new File("\${it.sourceSets.main.output.classesDirs}").exists()) {
+                logger.info("Class directory exists in sub project: \${it.name}")
+                logger.info("Adding class files \${it.sourceSets.main.output.classesDirs}")
+                classDirectories += fileTree(dir: "\${it.sourceSets.main.output.classesDirs}", includes: jacocoIncludes, excludes: jacocoExcludes)
+            } else {
+                logger.error("Class directory does not exist in sub project: \${it.name}")
+            }
+        }
+    }
+
+    reports {
+        html.enabled = true
+        xml.enabled = true
+        xml.destination file("report/dir/summary.xml")
+        html.destination file("report/dir/")
+    }
+}`;
+
+export const coberturaGradleSingleModule = `
+allprojects {
+    repositories {
+        mavenCentral()
+    }
+    apply plugin: 'net.saliman.cobertura'
+
+    dependencies {
+        testCompile 'org.slf4j:slf4j-api:1.7.12'
+    }
+
+    cobertura.coverageIncludes = ['**/*$ViewInjector.class','**/*$ViewBinder.class']
+    cobertura.coverageExcludes = ['**/R.class','**/R$.class']
+}
+
+cobertura {
+    coverageDirs = ["some/folder/with/classes"]
+    coverageSourceDirs = source/dir
+    coverageReportDir = new File('report/dir')
+    coverageFormats = ['xml', 'html']
+}`;
+
+export const coberturaGradleSingleModuleWithNotSpecifiedSourceDir = `
+allprojects {
+    repositories {
+        mavenCentral()
+    }
+    apply plugin: 'net.saliman.cobertura'
+
+    dependencies {
+        testCompile 'org.slf4j:slf4j-api:1.7.12'
+    }
+
+    cobertura.coverageIncludes = ['**/*$ViewInjector.class','**/*$ViewBinder.class']
+    cobertura.coverageExcludes = ['**/R.class','**/R$.class']
+}
+
+cobertura {
+    coverageDirs = ["some/folder/with/classes"]
+    coverageSourceDirs = project.sourceSets.main.java.srcDirs
+    coverageReportDir = new File('report/dir')
+    coverageFormats = ['xml', 'html']
+}`;
+
+export const coberturaGradleSingleModuleWithNotSpecifiedClassDir = `
+allprojects {
+    repositories {
+        mavenCentral()
+    }
+    apply plugin: 'net.saliman.cobertura'
+
+    dependencies {
+        testCompile 'org.slf4j:slf4j-api:1.7.12'
+    }
+
+    cobertura.coverageIncludes = ['**/*$ViewInjector.class','**/*$ViewBinder.class']
+    cobertura.coverageExcludes = ['**/R.class','**/R$.class']
+}
+
+cobertura {
+    coverageDirs = ["\${project.sourceSets.main.output.classesDirs}"]
+    coverageSourceDirs = source/dir
+    coverageReportDir = new File('report/dir')
+    coverageFormats = ['xml', 'html']
+}`;
+
+export const coberturaGradleMultiModule = `
+allprojects {
+    repositories {
+        mavenCentral()
+    }
+    apply plugin: 'net.saliman.cobertura'
+
+    dependencies {
+        testCompile 'org.slf4j:slf4j-api:1.7.12'
+    }
+
+    cobertura.coverageIncludes = ['**/*$ViewInjector.class','**/*$ViewBinder.class']
+    cobertura.coverageExcludes = ['**/R.class','**/R$.class']
+}
+
+test {
+    dependsOn = subprojects.test
+}
+
+cobertura {
+    coverageSourceDirs = []
+        coverageDirs = ["some/folder/with/classes"]
+    coverageDirs = ["source/dir"]
+    coverageFormats = [ 'xml', 'html' ]
+    coverageMergeDatafiles = subprojects.collect { new File(it.projectDir, '/build/cobertura/cobertura.ser') }
+    coverageReportDir = new File('report/dir')
+}`;
+
+export const coberturaGradleMultiModuleWithNotSpecifiedSourceDir = `
+allprojects {
+    repositories {
+        mavenCentral()
+    }
+    apply plugin: 'net.saliman.cobertura'
+
+    dependencies {
+        testCompile 'org.slf4j:slf4j-api:1.7.12'
+    }
+
+    cobertura.coverageIncludes = ['**/*$ViewInjector.class','**/*$ViewBinder.class']
+    cobertura.coverageExcludes = ['**/R.class','**/R$.class']
+}
+
+test {
+    dependsOn = subprojects.test
+}
+
+cobertura {
+    coverageSourceDirs = []
+        coverageDirs = ["some/folder/with/classes"]
+    rootProject.subprojects.each {
+        coverageSourceDirs += it.sourceSets.main.java.srcDirs
+    }
+    coverageFormats = [ 'xml', 'html' ]
+    coverageMergeDatafiles = subprojects.collect { new File(it.projectDir, '/build/cobertura/cobertura.ser') }
+    coverageReportDir = new File('report/dir')
+}`;
+
+export const coberturaGradleMultiModuleWithNotSpecifiedClassDir = `
+allprojects {
+    repositories {
+        mavenCentral()
+    }
+    apply plugin: 'net.saliman.cobertura'
+
+    dependencies {
+        testCompile 'org.slf4j:slf4j-api:1.7.12'
+    }
+
+    cobertura.coverageIncludes = ['**/*$ViewInjector.class','**/*$ViewBinder.class']
+    cobertura.coverageExcludes = ['**/R.class','**/R$.class']
+}
+
+test {
+    dependsOn = subprojects.test
+}
+
+cobertura {
+    coverageSourceDirs = []
+    rootProject.subprojects.each {
+        coverageDirs << file("\${it.sourceSets.main.output.classesDirs}")
+    }
+    coverageDirs = ["source/dir"]
+    coverageFormats = [ 'xml', 'html' ]
+    coverageMergeDatafiles = subprojects.collect { new File(it.projectDir, '/build/cobertura/cobertura.ser') }
+    coverageReportDir = new File('report/dir')
+}`;
+
+export const jacocoMavenSingleProject = {
+    "groupId": "org.jacoco",
+    "artifactId": "jacoco-maven-plugin",
+    "version": "0.8.7",
+    "configuration": {
+        "destFile": "report\\dir\\jacoco.exec",
+        "outputDirectory": "report/dir",
+        "dataFile": "report\\dir\\jacoco.exec",
+        "includes": [{
+            "include": [
+                '**/*$ViewInjector.class',
+                '**/*$ViewBinder.class'
+            ],
+        }],
+        "excludes": [{
+            "exclude": [
+                '**/R.class',
+                '**/R$.class'
+            ]
+        }]
+    },
+    "executions": {
+        "execution": [
+            {
+                "configuration":
+                {
+                    "includes": [{
+                        "include": "**/*",
+                    }]
+                },
+                "id": "default-prepare-agent-vsts",
+                "goals": { "goal": "prepare-agent" }
+            },
+            {
+                "id": "default-report-vsts",
+                "goals": { "goal": "report" },
+                "phase": "test"
+            }
+        ]
+    }
+};
+
+export const jacocoMavenMultiProject = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>VstsReport</groupId>
+  <artifactId>VstsReport</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
+        <executions>
+          <execution>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <echo message="Generating JaCoCo Reports" />
+                <taskdef name="report" classname="org.jacoco.ant.ReportTask">
+                  <classpath path="{basedir}/target/jacoco-jars/org.jacoco.ant.jar" />
+                </taskdef>
+                <report>
+                  <executiondata>
+                    <file file="report\\dir\\jacoco.exec" />
+                  </executiondata>
+                  <structure name="Jacoco report">
+                    <classfiles>
+                      <fileset dir="some/folder1/with/classes" includes="'**/*$ViewInjector.class','**/*$ViewBinder.class'" excludes="'**/R.class','**/R$.class'" />${os.EOL}<fileset dir="some/folder2/with/classes" includes="'**/*$ViewInjector.class','**/*$ViewBinder.class'" excludes="'**/R.class','**/R$.class'" />${os.EOL}
+                    </classfiles>
+                    <sourcefiles encoding="UTF-8">
+                      <fileset dir="source/dir1" />${os.EOL}<fileset dir="source/dir2" />${os.EOL}
+                    </sourcefiles>
+                  </structure>
+                  <html destdir="report/dir" />
+                  <xml destfile="report/dir\\jacoco.xml" />
+                  <csv destfile="report/dir\\report.csv" />
+                </report>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.ant</artifactId>
+            <version>0.8.7</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+    `
+
+export const coberturaMavenEnableConfiguration = `
+    <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cobertura-maven-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <formats>
+            <format>xml</format>
+            <format>html</format>
+          </formats>
+          <instrumentation>
+            <includes><include>'**/*$ViewInjector.class'</include>${os.EOL}<include>'**/*$ViewBinder.class'</include>${os.EOL}</includes>
+            <excludes><exclude>'**/R.class'</exclude>${os.EOL}<exclude>'**/R$.class'</exclude>${os.EOL}</excludes>
+          </instrumentation>
+          <aggregate>aggregateFake</aggregate>
+        </configuration>
+        <executions>
+          <execution>
+            <id>package-9af52907-6506-4b87-b16a-9883edee41bc</id>
+            <goals>
+              <goal>cobertura</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+    </plugin>
+  `;
+
+export const jacocoAntReportConfiguration = `<?xml version="1.0"?>
+<project name="JacocoReport">
+    <target name="CodeCoverage_9064e1d0">
+        <jacoco:report xmlns:jacoco="antlib:org.jacoco.ant">
+            <executiondata>
+                <file file="report\\dir\\jacoco.exec"/>
+            </executiondata>
+            <structure name="Jacoco report">
+                <classfiles>some/folder/with/classes</classfiles>
+                <sourcefiles>source/dir</sourcefiles>
+            </structure>
+            <html destdir="report/dir" />
+            <csv destfile="report/dir\\summary.csv" />
+            <xml destfile="report/dir\\summary.xml" />
+        </jacoco:report>
+    </target>
+</project>
+    `
+
+export const jacocoAntCoverageEnableConfiguration = {
+    $:
+    {
+        "destfile": "report\\dir\\jacoco.exec",
+        "xmlns:jacoco": "antlib:org.jacoco.ant"
+    }
+};
+
+export const coberturaAntReportConfiguration = `<?xml version="1.0"?>
+<project name="CoberturaReport">
+  <property environment="env" />
+  <path id="cobertura-classpath" description="classpath for instrumenting classes">
+    <fileset dir="\${env.COBERTURA_HOME}">
+      <include name="cobertura*.jar" />
+      <include name="**/lib/**/*.jar" />
+    </fileset>
+  </path>
+  <taskdef classpathref="cobertura-classpath" resource="tasks.properties" />
+  <target name="CodeCoverage_9064e1d0">
+    <cobertura-report format="html" destdir="report/dir" datafile="report/dir\\cobertura.ser" srcdir="source/dir" />
+    <cobertura-report format="xml" destdir="report/dir" datafile="report/dir\\cobertura.ser" srcdir="source/dir" />
+  </target>
+</project>
+    `;
+
+export const coberturaAntInstrumentedClassesConfiguration = `
+<cobertura-instrument todir="base\\dir\\InstrumentedClasses" datafile="report\\dir\\cobertura.ser">
+    some/folder/with/classes
+</cobertura-instrument>
+  `;
+
+export const coberturaAntPropertiesConfiguration = `
+        <sysproperty key="net.sourceforge.cobertura.datafile" file="report\\dir\\cobertura.ser" />
+        <classpath location="base\\dir\\InstrumentedClasses" />
+`;
+
+export const emptyFilters = {
+    includeFilter: "",
+    excludeFilter: ""
+}
+
+export const correctFilters = {
+    includeFilter: ":**/R:**/R$:**/BuildConfig",
+    excludeFilter: ":**/*$ViewInjector:**/*$ViewBinder:**/Manifest"
+}
+
+export const sortedStringArray = ['a', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'];
+
+export const emptyObjectWithAddedProperty = {
+    someProperty: 108
+}
+
+export const objectWithAddedProperty = {
+    firstProperty: "First Value",
+    secondProperty: "Second Value",
+    someProperty: 108
+}
+
+export const objectWithAddedPropertyIntoArray = {
+    firstProperty: "First Value",
+    secondProperty: "Second Value",
+    someProperty: [42, 108]
+}
+
+export const arrayWithAddedProperty = [
+    {
+        firstProperty: "First Value",
+        secondProperty: "Second Value",
+    },
+    {
+        firstProperty: "First Value",
+    },
+    {
+        someProperty: 108
+    }
+]
+
+export const arrayWithAppendedProperty = [
+    {
+        firstProperty: "First Value"
+    },
+    {
+        firstProperty: "First Value",
+        someProperty: [42, 108]
+    }
+]
+
+export const jacocoGradleCorrectedAppliedFilterPatter = [
+    "'**/R.class'",
+    "'**/R$.class'",
+    "'**/BuildConfig*/**'"
+]
+
+export const coberturaGradleCorrectedAppliedFilterPatter = [
+    "'.***/R'",
+    "'.***/R$'",
+    "'.***/BuildConfig.*'"
+]
+
+export const jacocoAntCorrectedAppliedFilterPatter = [
+    "**/**/R.class",
+    "**/**/R$.class",
+    "**/**/BuildConfig*/**"
+]
+
+export const coberturaAntCorrectedAppliedFilterPatter = [
+    "**/**/R.class",
+    "**/**/R$.class",
+    "**/**/BuildConfig*/**"
+]
+
+export const jacocoMavenCorrectedAppliedFilterPatter = [
+    "**/**/R.class",
+    "**/**/R$.class",
+    "**/**/BuildConfig*/**"
+]
+
+export const coberturaMavenCorrectedAppliedFilterPatter = [
+    "**/R.class",
+    "**/R$.class",
+    "**/BuildConfig*/**"
+]
+
+export const getSourceFilterResultSourceDirsNull = `<fileset dir="."/>${os.EOL}`;
+export const getSourceFilterResult = `<fileset dir="source/dir1"/>${os.EOL}<fileset dir="source/dir2"/>${os.EOL}`;
+export const addCodeCoverageDataJacoco = [
+    "addCodeCoveragePluginData result",
+    "createReportFile result"
+]
+export const addCodeCoverageDataCobertura = [
+    "addCodeCoverageNodes result",
+    "createReportFile result"
+]
+export const addCodeCoverageNodesTargetString = {
+    project: {
+        target: {
+            enableForking: true
+        }
+    }
+}
+export const addCodeCoverageNodesTargetArray = {
+    project: {
+        target: [
+            {
+                "enableForking": true
+            },
+            {
+                "enableForking": true
+            },
+            {
+                "enableForking": true
+            }
+        ]
+    }
+}
+
+export const enableForkingWithoutFilters = {
+  "jacoco:coverage": {
+    $: {
+      destfile: "some/dir/with/file.build",
+      "xmlns:jacoco": "antlib:org.jacoco.ant"
+    },
+    junit: {
+      enableForkOnTestNodes: true
+    }
+  }
+}
+
+export const enableForkingWithIncludingFilter = {
+  "jacoco:coverage": {
+    $: {
+      destfile: "some/dir/with/file.build",
+      includes: [
+        "**/*$ViewInjector.class",
+        "**/*$ViewBinder.class"
+      ],
+      "xmlns:jacoco": "antlib:org.jacoco.ant"
+    },
+    junit: {
+      enableForkOnTestNodes: true
+    }
+  }
+}
+
+export const enableForkingWithExcludingFilter = {
+  "jacoco:coverage": {
+    $: {
+      destfile: "some/dir/with/file.build",
+      excludes: [
+        '**/R.class',
+        '**/R$.class'
+      ],
+      "xmlns:jacoco": "antlib:org.jacoco.ant"
+    },
+    junit: {
+      enableForkOnTestNodes: true
+    }
+  }
+}
+
+export const enableForkOnTestNodesNotArrayWithForkModeEnabled = {
+    $: {
+        fork: 'true',
+        forkmode: 'once'
+    }
+}
+
+export const enableForkOnTestNodesNotArrayWithForkModeDisabled = {
+    $: {
+        fork: 'true'
+    }
+}
+
+export const enableForkOnTestNodesArrayWithForkModeEnabled = [
+    {
+        element: 'first',
+        $: {
+            fork: 'true',
+            forkmode: 'once'
+        }
+    },
+    {
+        element: 'second',
+        $: {
+            fork: 'true',
+            forkmode: 'once'
+        }
+    }
+]
+
+export const enableForkOnTestNodesArrayWithForkModeDisabled = [
+    {
+        element: 'first',
+        '$': {
+            fork: 'true'
+        }
+    },
+    {
+        element: 'second',
+        '$': {
+            fork: 'true'
+        }
+    }
+]
+
+export const getClassDataResult = `
+            <fileset dir="some/folder1/with/classes" includes="'**/*$ViewInjector.class','**/*$ViewBinder.class'" excludes="'**/R.class','**/R$.class'" />
+            
+            <fileset dir="some/folder2/with/classes" includes="'**/*$ViewInjector.class','**/*$ViewBinder.class'" excludes="'**/R.class','**/R$.class'" />
+            `;
+            
+export const getClassDataResultWhenClassDirsEmpty = `
+            <fileset dir="." includes="'**/*$ViewInjector.class','**/*$ViewBinder.class'" excludes="'**/R.class','**/R$.class'" />
+            `;
+            
+export const addCodeCoverageNodesCoberturaResult = `<project>
+    <coberturaAntCoverageEnable/>
+    <target/>
+    <target/>
+    <target/>
+</project>`
+
+export const enableForkOnTestNodesCoberturaResult = '<node forkmode="once" fork="true" />'
+export const enableForkingWithoutCoberturaInstrument = '<project><target><cobertura-instrument>some/folder/with/classes</cobertura-instrument><junit><coberturaAntProperties/><coberturaAntClasspathRef/></junit></target></project>';
+export const enableForkingWithCoberturaInstrument = '<project><target><cobertura-instrument>exist cobertura node</cobertura-instrument><junit><coberturaAntProperties/><coberturaAntClasspathRef/></junit></target></project>';
+export const enableForkingWithoutTarget = '<project><target/></project>';
+export const enableForkingWithJavac = '<project><target><javac debug="true"/></target></project>';
+export const addCodeCoverageDataSingleProject = ['addCodeCoveragePluginData'];
+export const addCodeCoverageDataMultiProject = [
+    'addCodeCoveragePluginData',
+    'createMultiModuleReport'
+];
+
+export const getBuildDataNodeBuildString = {};
+export const getBuildDataNodeBuildJsonContentBuildString = { project: { build: {} } };
+export const getBuildDataNodeBuildArray = { element: 'some value' };
+export const getBuildDataNodeBuildJsonContentBuildArray = { project: { build: [{ element: 'some value' }] } };
+export const getBuildDataNodeBuildArrayWithStringElement = {};
+export const getBuildDataNodeBuildJsonContentBuildArrayWithStringElement = { project: { build: [{}] } };
+export const getPluginDataNodeWithoutPluginsNode = {};
+export const getPluginDataNodeWithoutPluginsNodeConfig = { project: {}, plugins: {}};
+export const getPluginDataNodePluginsString = {};
+export const getPluginDataNodePluginsStringConfig = { project: {}, plugins: {}};
+export const getPluginDataNodePluginsStringArray = {};
+export const getPluginDataNodePluginsStringArrayConfig = { project: {}, plugins: [{}]};
+export const getPluginDataNodePluginsArray = { name: 'some name' };
+export const getPluginDataNodePluginsArrayConfig = { project: {}, plugins: [{ name: 'some name' }]};
+export const getPluginDataNodePluginsAnother = { name: 'some name' };
+export const getPluginDataNodePluginsAnotherConfig = { project: {}, plugins: { name: 'some name' }};
+export const getReportingPluginNodeArray = { node: 'some value' };
+export const getReportingPluginNodeAnother = { node: 'some value' };
+export const addCodeCoverageNodesSingleModule = {
+    project: {
+        build: {
+            plugins: {
+                name: 'plugin'
+            }
+        }
+    }
+};
+export const addCodeCoverageNodesMultiModule = {
+    project: {
+        build: {},
+        modules: {}
+    }
+};

--- a/Tests/data/expectedResults.ts
+++ b/Tests/data/expectedResults.ts
@@ -247,11 +247,8 @@ cobertura {
 export const jacocoMavenSingleProject = {
     "groupId": "org.jacoco",
     "artifactId": "jacoco-maven-plugin",
-    "version": "0.8.7",
+    "version": "0.8.8",
     "configuration": {
-        "destFile": "report\\dir\\jacoco.exec",
-        "outputDirectory": "report/dir",
-        "dataFile": "report\\dir\\jacoco.exec",
         "includes": [{
             "include": [
                 '**/*$ViewInjector.class',
@@ -287,62 +284,33 @@ export const jacocoMavenSingleProject = {
 };
 
 export const jacocoMavenMultiProject = `<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>VstsReport</groupId>
-  <artifactId>VstsReport</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-  <packaging>pom</packaging>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.8</version>
-        <executions>
-          <execution>
-            <phase>post-integration-test</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <target>
-                <echo message="Generating JaCoCo Reports" />
-                <taskdef name="report" classname="org.jacoco.ant.ReportTask">
-                  <classpath path="{basedir}/target/jacoco-jars/org.jacoco.ant.jar" />
-                </taskdef>
-                <report>
-                  <executiondata>
-                    <file file="report\\dir\\jacoco.exec" />
-                  </executiondata>
-                  <structure name="Jacoco report">
-                    <classfiles>
-                      <fileset dir="some/folder1/with/classes" includes="'**/*$ViewInjector.class','**/*$ViewBinder.class'" excludes="'**/R.class','**/R$.class'" />${os.EOL}<fileset dir="some/folder2/with/classes" includes="'**/*$ViewInjector.class','**/*$ViewBinder.class'" excludes="'**/R.class','**/R$.class'" />${os.EOL}
-                    </classfiles>
-                    <sourcefiles encoding="UTF-8">
-                      <fileset dir="source/dir1" />${os.EOL}<fileset dir="source/dir2" />${os.EOL}
-                    </sourcefiles>
-                  </structure>
-                  <html destdir="report/dir" />
-                  <xml destfile="report/dir\\jacoco.xml" />
-                  <csv destfile="report/dir\\report.csv" />
-                </report>
-              </target>
-            </configuration>
-          </execution>
-        </executions>
-        <dependencies>
-          <dependency>
-            <groupId>org.jacoco</groupId>
-            <artifactId>org.jacoco.ant</artifactId>
-            <version>0.8.7</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-    </plugins>
-  </build>
-</project>
-    `
+        <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+            <modelVersion>4.0.0</modelVersion>
+            <groupId>some.group.plugins</groupId>
+            <artifactId>report-artifact-id</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <packaging>pom</packaging>
+            <modules><module name="module"></module></modules>
+            <parentData></parentData>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.8.8</version>
+                        <executions>
+                            <execution>
+                                <id>jacoco-report-aggregate</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report-aggregate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </project>`;
 
 export const coberturaMavenEnableConfiguration = `
     <plugin>
@@ -658,12 +626,10 @@ export const enableForkingWithoutCoberturaInstrument = '<project><target><cobert
 export const enableForkingWithCoberturaInstrument = '<project><target><cobertura-instrument>exist cobertura node</cobertura-instrument><junit><coberturaAntProperties/><coberturaAntClasspathRef/></junit></target></project>';
 export const enableForkingWithoutTarget = '<project><target/></project>';
 export const enableForkingWithJavac = '<project><target><javac debug="true"/></target></project>';
-export const addCodeCoverageDataSingleProject = ['addCodeCoveragePluginData'];
-export const addCodeCoverageDataMultiProject = [
-    'addCodeCoveragePluginData',
-    'createMultiModuleReport'
-];
-
+export const addCodeCoverageDataSingleProject = 'report\\target\\site\\jacoco';
+export const addCodeCoverageDataSingleProjectConfig = { project: {} };
+export const addCodeCoverageDataMultiProject = 'report\\dir\\target\\site\\jacoco-aggregate';
+export const addCodeCoverageDataMultiProjectConfig = { project: { modules: [{ module: ['dir'] }] }};
 export const getBuildDataNodeBuildString = {};
 export const getBuildDataNodeBuildJsonContentBuildString = { project: { build: {} } };
 export const getBuildDataNodeBuildArray = { element: 'some value' };

--- a/Tests/data/fakeData.ts
+++ b/Tests/data/fakeData.ts
@@ -1,0 +1,80 @@
+import * as cheerio from 'cheerio';
+
+export const excludeFilter = [
+    '**/R.class',
+    '**/R$.class'
+];
+export const excludeFilterStringified = `'${excludeFilter.join('\',\'')}'`;
+export const excludeFilterStringifiedWithComma = excludeFilter.join(',');
+export const includeFilter = [
+    '**/*$ViewInjector.class',
+    '**/*$ViewBinder.class'
+];
+export const includeFilterStringified = `'${includeFilter.join('\',\'')}'`;
+export const includeFilterStringifiedWithComma = includeFilter.join(',');
+export const classDir = 'some/folder/with/classes';
+export const classDirs = 'some/folder1/with/classes,some/folder2/with/classes';
+export const sourceDir = 'source/dir';
+export const sourceDirs = 'source/dir1,source/dir2';
+export const reportDir = 'report/dir';
+export const getFormattedFileCollectionAssignGradleOutput = 'fileCollectionAssign';
+export const aggregate = 'aggregateFake';
+export const baseDir = 'base/dir'
+export const invalidClassFilter1 = '-:**/R,-';
+export const invalidClassFilter2 = '-:**/R,?:**/R$,-:**/*$ViewInjector';
+export const classFilter = '+:**/R,+:**/R$,-:**/*$ViewInjector,-:**/*$ViewBinder,+:**/BuildConfig,-:**/Manifest';
+export const sharedSubString1 = "abcd";
+export const sharedSubString2 = "efhg";
+export const sharedSubString3 = "abhg";
+export const stringArray = ['g', 'b', 'a', 'p', 'f', 'c', 's', 'e', 'a', 't', 'o', 'u', 'q', 'r', 'y', 'd', 'z', 'v', 'x', 'n', 'h', 'w', 'i', 'l', 'j', 'm', 'k'];
+export const string = "fake string";
+export const propertyName = "someProperty";
+export const propertyValue = 108;
+export const filtersWithNotAppliedFilterPattern = ":**/R:**/R$:**/BuildConfig*";
+export const buildFile = '/build/file/path/build.gradle';
+export const reportBuildFile = 'report/build/file/report.file';
+export const summaryFile = 'coverageSummary.xml'
+export const filters = {
+    includeFilter: ":**/R:**/R$:**/BuildConfig",
+    excludeFilter: ":**/*$ViewInjector:**/*$ViewBinder:**/Manifest"
+}
+export const AntBuildConfigurationJSONWithoutProject = {
+    someProperty: 108
+}
+export const AntBuildConfigurationJSONWithProject = {
+    project: {},
+    someProperty: 108
+}
+export const cherioObjWithProjectNode = cheerio.load('<project></project><node></node>', <CheerioOptionsInterface>{ xmlMode: true, withDomLvl1: false });
+export const cherioObjWithoutProjectNode = cheerio.load('<node></node>', <CheerioOptionsInterface>{ xmlMode: true, withDomLvl1: false });
+export const coberturaAntBuildConfigurationWithTarget = cheerio.load(`<project>
+    <target></target>
+    <target></target>
+    <target></target>
+</project>`, <CheerioOptionsInterface>{ xmlMode: true, withDomLvl1: false });
+export const nodeToEnableFork = cheerio.load('<node/>', <CheerioOptionsInterface>{ xmlMode: true, withDomLvl1: false })('node').get()[0] as unknown as CheerioElement;
+export const enableForkingBuildConfigWithTargetConfig = cheerio.load('<project><target><junit/></target></project>', <CheerioOptionsInterface>{ xmlMode: true, withDomLvl1: false });
+export const enableForkingBuildConfigWithTargetNode = enableForkingBuildConfigWithTargetConfig('target').get()[0] as unknown as CheerioElement;
+export const enableForkingBuildConfigWithTargetAndCoberturaConfig = cheerio.load('<project><target><cobertura-instrument>exist cobertura node</cobertura-instrument><junit/></target></project>', <CheerioOptionsInterface>{ xmlMode: true, withDomLvl1: false });
+export const enableForkingBuildConfigWithTargetAndCoberturaNode = enableForkingBuildConfigWithTargetAndCoberturaConfig('target').get()[0] as unknown as CheerioElement;
+export const enableForkingBuildConfigWithoutTargetConfig = cheerio.load('<project><target/></project>', <CheerioOptionsInterface>{ xmlMode: true, withDomLvl1: false });
+export const enableForkingBuildConfigWithoutTargetNode = enableForkingBuildConfigWithoutTargetConfig('target').get()[0] as unknown as CheerioElement;
+export const enableForkingBuildConfigWithJavacConfig = cheerio.load('<project><target><javac/></target></project>', <CheerioOptionsInterface>{ xmlMode: true, withDomLvl1: false });
+export const enableForkingBuildConfigWithJavacNode = enableForkingBuildConfigWithJavacConfig('target').get()[0] as unknown as CheerioElement;
+export const addCodeCoverageDataPomJsonSingle = { project: {} };
+export const addCodeCoverageDataPomJsonMulti = { project: { modules: [] } };
+export const addCodeCoverageDataPomJsonWithoutProject = { node: {} };
+export const getBuildDataNodeBuildJsonContentBuildString = () => ({ project: { build: "string value" } });
+export const getBuildDataNodeBuildJsonContentBuildArray = () => ({ project: { build: [{ element: 'some value' }] } });
+export const getBuildDataNodeBuildJsonContentBuildArrayWithStringElement = () => ({ project: { build: ["string value"] } });
+export const getPluginDataNodeWithoutPluginsNode = () => ({ project: {}});
+export const getPluginDataNodePluginsString = () => ({ project: {}, plugins: 'string value' });
+export const getPluginDataNodePluginsArray = () => ({ project: {}, plugins: [{ name: 'some name' }]});
+export const getPluginDataNodePluginsStringArray = () => ({ project: {}, plugins: ['some name'] });
+export const getPluginDataNodePluginsAnother = () => ({ project: {}, plugins: { name: 'some name' }});
+export const getReportingPluginNodeString = () => 'some string';
+export const getReportingPluginNodeArray = () => [{ plugins: { node: 'some value' } }];
+export const getReportingPluginNodeAnother = () => ({ plugins: { node: 'some value' } });
+export const addCodeCoverageNodesWithoutProject = { node: {} }
+export const addCodeCoverageNodesSingleProjectWithBuildNode = () => ({ project: { build: { plugins: { name: 'plugin'}} } });
+export const addCodeCoverageNodesMultiProject = () => ({ project: { modules: {} } });

--- a/Tests/data/fakeData.ts
+++ b/Tests/data/fakeData.ts
@@ -17,6 +17,11 @@ export const classDirs = 'some/folder1/with/classes,some/folder2/with/classes';
 export const sourceDir = 'source/dir';
 export const sourceDirs = 'source/dir1,source/dir2';
 export const reportDir = 'report/dir';
+export const groupId = 'some.group.plugins';
+export const parentData = {groupId: groupId};
+export const formattedParentData = '<parentData></parentData>';
+export const modules = '<modules><module name="module"></module></modules>';
+export const reportArtifactId = 'report-artifact-id';
 export const getFormattedFileCollectionAssignGradleOutput = 'fileCollectionAssign';
 export const aggregate = 'aggregateFake';
 export const baseDir = 'base/dir'
@@ -62,7 +67,7 @@ export const enableForkingBuildConfigWithoutTargetNode = enableForkingBuildConfi
 export const enableForkingBuildConfigWithJavacConfig = cheerio.load('<project><target><javac/></target></project>', <CheerioOptionsInterface>{ xmlMode: true, withDomLvl1: false });
 export const enableForkingBuildConfigWithJavacNode = enableForkingBuildConfigWithJavacConfig('target').get()[0] as unknown as CheerioElement;
 export const addCodeCoverageDataPomJsonSingle = { project: {} };
-export const addCodeCoverageDataPomJsonMulti = { project: { modules: [] } };
+export const addCodeCoverageDataPomJsonMulti = { project: { modules: [{ module: [] }] } };
 export const addCodeCoverageDataPomJsonWithoutProject = { node: {} };
 export const getBuildDataNodeBuildJsonContentBuildString = () => ({ project: { build: "string value" } });
 export const getBuildDataNodeBuildJsonContentBuildArray = () => ({ project: { build: [{ element: 'some value' }] } });

--- a/Tests/data/stubs.ts
+++ b/Tests/data/stubs.ts
@@ -1,0 +1,13 @@
+import * as fakeData from './fakeData'
+
+export const getFormattedFileCollectionAssignGradleOutput = function () { return fakeData.getFormattedFileCollectionAssignGradleOutput }
+export const jacocoAntCoverageEnableOutput = () => ({
+    $:
+    {
+        "destfile": "some/dir/with/file.build",
+        "xmlns:jacoco": "antlib:org.jacoco.ant"
+    }
+});
+export const coberturaAntPropertiesConfiguration = () => `<coberturaAntProperties />`;
+export const coberturaAntInstrumentedClassesConfiguration = () => `<cobertura-instrument>some/folder/with/classes</cobertura-instrument>`;
+export const coberturaAntClasspathRefConfiguration = () => `<coberturaAntClasspathRef />`;

--- a/Tests/jacocoantccenablerTests.ts
+++ b/Tests/jacocoantccenablerTests.ts
@@ -1,0 +1,358 @@
+import * as assert from 'assert';
+import * as ccc from "../codecoverageconstants";
+import * as expectedResults from './data/expectedResults';
+import * as fakeData from "./data/fakeData";
+import * as Q from "q";
+import * as rewire from 'rewire';
+import * as sinon from 'sinon';
+import * as stubs from './data/stubs'
+import * as tl from 'azure-pipelines-task-lib/task';
+import * as util from "../utilities";
+
+export function jacocoantccenablerTests() {
+    const sandbox = sinon.createSandbox();
+    const jacocoantccenablerRewired = rewire('../jacoco/jacoco.ant.ccenabler');
+    const jacocoAntCodeCoverageEnablerClass = jacocoantccenablerRewired.__get__('JacocoAntCodeCoverageEnabler')
+    const jacocoAntCodeCoverageEnablerInstance = new jacocoAntCodeCoverageEnablerClass();
+
+    before(() => {
+        // reset all fields of class to prevent unexpected behavior and to be able to stub them
+        jacocoAntCodeCoverageEnablerInstance.reportDir = null;
+        jacocoAntCodeCoverageEnablerInstance.excludeFilter = null;
+        jacocoAntCodeCoverageEnablerInstance.includeFilter = null;
+        jacocoAntCodeCoverageEnablerInstance.sourceDirs = null;
+        jacocoAntCodeCoverageEnablerInstance.classDirs = null;
+        jacocoAntCodeCoverageEnablerInstance.reportBuildFile = null;
+        jacocoAntCodeCoverageEnablerInstance.excludeFilterExec = null;
+        jacocoAntCodeCoverageEnablerInstance.includeFilterExec = null;
+    });
+
+    describe('function enableCodeCoverage', () => {
+        let extractFiltersStub, excludeFilterExecStub, includeFilterExecStub, applyFilterPatternStub;
+
+        before(() => {
+            sandbox.stub(tl, "debug").callsFake();
+            extractFiltersStub = sandbox.stub(jacocoAntCodeCoverageEnablerInstance, 'extractFilters').callsFake();
+            excludeFilterExecStub = sandbox.stub(jacocoAntCodeCoverageEnablerInstance, 'excludeFilterExec');
+            includeFilterExecStub = sandbox.stub(jacocoAntCodeCoverageEnablerInstance, 'includeFilterExec');
+            applyFilterPatternStub = sandbox.stub(jacocoAntCodeCoverageEnablerInstance, 'applyFilterPattern').callsFake();
+            sandbox.stub(util, 'readXmlFileAsJson').returns(Q.resolve(() => ({ node: {} })));
+            sandbox.stub(jacocoAntCodeCoverageEnablerInstance, 'addCodeCoverageData').returns(Q.resolve(() => ([])));
+        });
+
+        after(() => {
+            sandbox.restore();
+        });
+
+        afterEach(() => {
+            extractFiltersStub.reset();
+            excludeFilterExecStub.reset();
+            includeFilterExecStub.reset();
+            applyFilterPatternStub.reset();
+        })
+
+        it('should remove colon in excludeFilter and includeFilter', async () => {
+            extractFiltersStub.returns({
+                excludeFilter: ':excludeFilter',
+                includeFilter: ':includeFilter'
+            });
+            applyFilterPatternStub.returns([]);
+            await jacocoAntCodeCoverageEnablerInstance.enableCodeCoverage({
+                reportDir: null,
+                excludeFilter: null,
+                includeFilter: null,
+                sourceDirs: null,
+                classDirs: null,
+                reportBuildFile: null,
+                excludeFilterExec: null,
+                includeFilterExec: null
+            });
+            assert.strictEqual(jacocoAntCodeCoverageEnablerInstance.excludeFilterExec, 'excludeFilter');
+            assert.strictEqual(jacocoAntCodeCoverageEnablerInstance.includeFilterExec, 'includeFilter');
+        });
+
+        it('should join result of applyFilterPattern function with comma', async () => {
+            extractFiltersStub.returns({
+                excludeFilter: 'excludeFilter',
+                includeFilter: 'includeFilter'
+            });
+            applyFilterPatternStub
+                .onFirstCall().returns(["first", "second"])
+                .onSecondCall().returns(["third", "fourth"]);
+            await jacocoAntCodeCoverageEnablerInstance.enableCodeCoverage({
+                reportDir: null,
+                excludeFilter: null,
+                includeFilter: null,
+                sourceDirs: null,
+                classDirs: null,
+                reportBuildFile: null,
+                excludeFilterExec: null,
+                includeFilterExec: null
+            });
+            assert.strictEqual(jacocoAntCodeCoverageEnablerInstance.excludeFilter, 'first,second');
+            assert.strictEqual(jacocoAntCodeCoverageEnablerInstance.includeFilter, 'third,fourth');
+        });
+    });
+
+    describe('function applyFilterPattern', () => {
+        let isNullOrWhitespaceStub;
+
+        before(() => {
+            sandbox.stub(tl, "debug").callsFake();
+            sandbox.stub(util, "trimToEmptyString").callsFake((value) => value);
+            isNullOrWhitespaceStub = sandbox.stub(util, "isNullOrWhitespace").callsFake();
+        });
+
+        after(() => {
+            sandbox.restore();
+        });
+
+        afterEach(() => {
+            isNullOrWhitespaceStub.reset();
+        })
+
+        it('should return empty array if filter is empty', () => {
+            isNullOrWhitespaceStub.returns(true);
+            const actual = jacocoAntCodeCoverageEnablerInstance.applyFilterPattern(fakeData.filtersWithNotAppliedFilterPattern);
+            assert.deepStrictEqual(actual, []);
+        });
+    
+        it('should return correct array of filters', () => {
+            isNullOrWhitespaceStub.returns(false);
+            const actual = jacocoAntCodeCoverageEnablerInstance.applyFilterPattern(fakeData.filtersWithNotAppliedFilterPattern);
+            assert.deepStrictEqual(actual, expectedResults.jacocoAntCorrectedAppliedFilterPatter);
+        });
+    });
+
+    describe('function getSourceFilter', () => {
+        let isNullOrWhitespaceStub, sourceDirsStub;
+
+        before(() => {
+            isNullOrWhitespaceStub = sandbox.stub(util, "isNullOrWhitespace").callsFake();
+            sourceDirsStub = sandbox.stub(jacocoAntCodeCoverageEnablerInstance, 'sourceDirs').value(null);
+        });
+
+        after(() => {
+            sandbox.restore();
+        });
+
+        afterEach(() => {
+            isNullOrWhitespaceStub.reset();
+            sourceDirsStub.reset();
+        });
+
+        it('should return correct structure if sourceDirs is null', () => {
+            isNullOrWhitespaceStub.returns(true);
+            sourceDirsStub.value(null); 
+            const actual =jacocoAntCodeCoverageEnablerInstance.getSourceFilter();
+            assert.strictEqual(actual, expectedResults.getSourceFilterResultSourceDirsNull);
+        });
+
+        it('should return correct structure', () => {
+            isNullOrWhitespaceStub.returns(false);
+            sourceDirsStub.value(fakeData.sourceDirs);
+            const actual =jacocoAntCodeCoverageEnablerInstance.getSourceFilter();
+            assert.strictEqual(actual, expectedResults.getSourceFilterResult);
+        });
+    });
+
+    describe('function addCodeCoverageData', () => {
+        before(() => {
+            sandbox.stub(tl, 'loc').callsFake(() => 'error');
+            sandbox.stub(jacocoAntCodeCoverageEnablerInstance, 'getSourceFilter').callsFake();
+            sandbox.stub(jacocoAntCodeCoverageEnablerInstance, 'getClassData').callsFake();
+            sandbox.stub(ccc, 'jacocoAntReport').callsFake();
+            sandbox.stub(jacocoAntCodeCoverageEnablerInstance, 'addCodeCoveragePluginData').resolves('addCodeCoveragePluginData result');
+            sandbox.stub(jacocoAntCodeCoverageEnablerInstance, 'createReportFile').resolves('createReportFile result');
+        });
+
+        after(() => {
+            sandbox.restore();
+        });
+
+        it('should reject if build configuration doesn\'t have project node', () => {
+            assert.rejects(jacocoAntCodeCoverageEnablerInstance.addCodeCoverageData(fakeData.AntBuildConfigurationJSONWithoutProject));
+        });
+
+        it('should return array with coverage plugin data and report file', async () => {
+            const actual = await jacocoAntCodeCoverageEnablerInstance.addCodeCoverageData(fakeData.AntBuildConfigurationJSONWithProject);
+            assert.deepStrictEqual(actual, expectedResults.addCodeCoverageDataJacoco);
+        });
+    });
+
+    describe('function addCodeCoverageNodes', () => {
+        before(() => {
+            sandbox.stub(tl, 'debug').callsFake();
+            sandbox.stub(jacocoAntCodeCoverageEnablerInstance, 'enableForking').callsFake((obj) => { obj.enableForking = true });
+        });
+
+        after(() => {
+            sandbox.restore();
+        });
+
+        it('should reject if project doesn\'t have target in build configuration', () => {
+            assert.rejects(jacocoAntCodeCoverageEnablerInstance.addCodeCoverageNodes(fakeData.AntBuildConfigurationJSONWithProject));
+        });
+
+        it('should add correct append coverage node if target is string', async () => {
+            const config = {
+                project: {
+                    target: 'some target'
+                }
+            }
+            await jacocoAntCodeCoverageEnablerInstance.addCodeCoverageNodes(config);
+            assert.deepStrictEqual(config, expectedResults.addCodeCoverageNodesTargetString);
+        });
+
+        it('should add correct append coverage node if target is array', async () => {
+            const config = {
+                project: {
+                    target: [
+                        {}, 
+                        {}, 
+                        {}
+                    ]
+                }
+            }
+            await jacocoAntCodeCoverageEnablerInstance.addCodeCoverageNodes(config);
+            assert.deepStrictEqual(config, expectedResults.addCodeCoverageNodesTargetArray);
+        });
+    });
+
+    describe('function enableForking', () => {
+        let isNullOrWhitespaceStub, excludeFilterExecStub, includeFilterExecStub;
+
+        before(() => {
+            isNullOrWhitespaceStub = sandbox.stub(util, "isNullOrWhitespace").callsFake();
+            sandbox.stub(ccc, 'jacocoAntCoverageEnable').callsFake(stubs.jacocoAntCoverageEnableOutput);
+            sandbox.stub(jacocoAntCodeCoverageEnablerInstance, 'enableForkOnTestNodes').callsFake((node, _) => { node.enableForkOnTestNodes = true });
+            excludeFilterExecStub = sandbox.stub(jacocoAntCodeCoverageEnablerInstance, 'excludeFilterExec');
+            includeFilterExecStub = sandbox.stub(jacocoAntCodeCoverageEnablerInstance, 'includeFilterExec');
+        });
+
+        after(() => {
+            sandbox.restore();
+        });
+
+        afterEach(() => {
+            isNullOrWhitespaceStub.reset();
+            excludeFilterExecStub.restore();
+            includeFilterExecStub.restore();
+        });
+
+        it('should return configuration without includeFilter and excludeFilter', () => {
+            isNullOrWhitespaceStub.returns(true);
+            const config = {
+                junit: {}
+            };
+            jacocoAntCodeCoverageEnablerInstance.enableForking(config);
+            assert.deepStrictEqual(config, expectedResults.enableForkingWithoutFilters);
+        });
+
+        it('should return configuration with include filter', () => {
+            isNullOrWhitespaceStub
+                .onCall(0).returns(false)
+                .returns(true);
+            includeFilterExecStub.value(fakeData.includeFilter);
+            const config = {
+                junit: {}
+            };
+            jacocoAntCodeCoverageEnablerInstance.enableForking(config);
+            assert.deepStrictEqual(config, expectedResults.enableForkingWithIncludingFilter);
+        });
+
+        it('should return configuration with exclude filter', () => {
+            isNullOrWhitespaceStub
+                .onCall(1).returns(false)
+                .returns(true);
+            excludeFilterExecStub.value(fakeData.excludeFilter);
+            const config = {
+                junit: {}
+            };
+            jacocoAntCodeCoverageEnablerInstance.enableForking(config);
+            assert.deepStrictEqual(config, expectedResults.enableForkingWithExcludingFilter);
+        });
+    });
+
+    describe('function enableForkOnTestNodes', () => {
+        it('should enable fork correctly with enabled Fork Mode when node \'$\' doesn\'t exist', () => {
+            const testNode = {};
+            jacocoAntCodeCoverageEnablerInstance.enableForkOnTestNodes(testNode, true);
+            assert.deepStrictEqual(testNode, expectedResults.enableForkOnTestNodesNotArrayWithForkModeEnabled);
+        });
+
+        it('should enable fork correctly with enabled Fork Mode when node \'$\' exists', () => {
+            const testNode = { $: {} };
+            jacocoAntCodeCoverageEnablerInstance.enableForkOnTestNodes(testNode, true);
+            assert.deepStrictEqual(testNode, expectedResults.enableForkOnTestNodesNotArrayWithForkModeEnabled);
+        });
+
+        it('should enable fork correctly with disabled Fork Mode when node \'$\' doesn\'t exist', () => {
+            const testNode = {};
+            jacocoAntCodeCoverageEnablerInstance.enableForkOnTestNodes(testNode, false);
+            assert.deepStrictEqual(testNode, expectedResults.enableForkOnTestNodesNotArrayWithForkModeDisabled);
+        });
+        
+        it('should enable fork correctly with disabled Fork Mode when node \'$\' exists', () => {
+            const testNode = { $: {} };
+            jacocoAntCodeCoverageEnablerInstance.enableForkOnTestNodes(testNode, false);
+            assert.deepStrictEqual(testNode, expectedResults.enableForkOnTestNodesNotArrayWithForkModeDisabled);
+        });
+
+        it('should enable fork correctly for array with enabled Fork Mode when node \'$\' doesn\'t exist', () => {
+            const testNode = [
+                {
+                    element: 'first'
+                },
+                {
+                    element: 'second'
+                }
+            ];
+            jacocoAntCodeCoverageEnablerInstance.enableForkOnTestNodes(testNode, true);
+            assert.deepStrictEqual(testNode, expectedResults.enableForkOnTestNodesArrayWithForkModeEnabled);
+        });
+
+        it('should enable fork correctly for array with enabled Fork Mode when node \'$\' exists', () => {
+            const testNode = [
+                {
+                    element: 'first',
+                    $: {}
+                },
+                {
+                    element: 'second',
+                    $: {}
+                }
+            ];
+            jacocoAntCodeCoverageEnablerInstance.enableForkOnTestNodes(testNode, true);
+            assert.deepStrictEqual(testNode, expectedResults.enableForkOnTestNodesArrayWithForkModeEnabled);
+        });
+
+        it('should enable fork correctly for array with disabled Fork Mode when node \'$\' doesn\'t exist', () => {
+            const testNode = [
+                {
+                    element: 'first',
+                },
+                {
+                    element: 'second',
+                }
+            ];
+            jacocoAntCodeCoverageEnablerInstance.enableForkOnTestNodes(testNode, false);
+            assert.deepStrictEqual(testNode, expectedResults.enableForkOnTestNodesArrayWithForkModeDisabled);
+        });
+        
+        it('should enable fork correctly for array with disabled Fork Mode when node \'$\' exists', () => {
+            const testNode = [
+                {
+                    element: 'first',
+                    $: {}
+                },
+                {
+                    element: 'second',
+                    $: {}
+                }
+            ];
+            jacocoAntCodeCoverageEnablerInstance.enableForkOnTestNodes(testNode, false);
+            assert.deepStrictEqual(testNode, expectedResults.enableForkOnTestNodesArrayWithForkModeDisabled);
+        });
+    });
+}

--- a/Tests/jacocogradleccenablerTests.ts
+++ b/Tests/jacocogradleccenablerTests.ts
@@ -1,0 +1,118 @@
+import * as assert from 'assert';
+import * as ccc from "../codecoverageconstants";
+import * as expectedResults from "./data/expectedResults";
+import * as fakeData from "./data/fakeData"
+import * as rewire from 'rewire';
+import * as sinon from 'sinon';
+import * as tl from 'azure-pipelines-task-lib/task';
+import * as util from "../utilities";
+
+export function jacocogradleccenablerTests() {
+    const sandbox = sinon.createSandbox();
+    const jacocogradleenablerRewired = rewire('../jacoco/jacoco.gradle.ccenabler');
+    const jacocoGradleCodeCoverageEnablerClass = jacocogradleenablerRewired.__get__('JacocoGradleCodeCoverageEnabler')
+    const jacocoGradleCodeCoverageEnablerInstance = new jacocoGradleCodeCoverageEnablerClass();
+
+    describe('function applyFilterPattern', () => {
+        let isNullOrWhitespaceStub;
+
+        before(() => {
+            sandbox.stub(tl, "debug").callsFake();
+            sandbox.stub(util, "trimToEmptyString").callsFake((value) => value);
+            isNullOrWhitespaceStub = sandbox.stub(util, "isNullOrWhitespace").callsFake();
+        });
+    
+        after(() => {
+            sandbox.restore();
+        });
+
+        afterEach(() => {
+            isNullOrWhitespaceStub.reset();
+        })
+
+        it('should return empty array if filter is empty', () => {
+            isNullOrWhitespaceStub.returns(true);
+            const actual = jacocoGradleCodeCoverageEnablerInstance.applyFilterPattern(fakeData.filtersWithNotAppliedFilterPattern);
+            assert.deepStrictEqual(actual, []);
+        });
+    
+        it('should return correct array of filters', () => {
+            isNullOrWhitespaceStub.returns(false);
+            const actual = jacocoGradleCodeCoverageEnablerInstance.applyFilterPattern(fakeData.filtersWithNotAppliedFilterPattern);
+            assert.deepStrictEqual(actual, expectedResults.jacocoGradleCorrectedAppliedFilterPatter);
+        });
+    });
+
+    describe('function enableCodeCoverage', () => {
+        let appendTextToFileSync;
+
+        before(() => {
+            sandbox.stub(tl, "debug").callsFake();
+            sandbox.stub(tl, "warning").callsFake();
+            sandbox.stub(tl, "loc").callsFake();
+            sandbox.stub(jacocoGradleCodeCoverageEnablerInstance, "extractFilters").returns(fakeData.filters);
+            sandbox.stub(jacocoGradleCodeCoverageEnablerInstance, "applyFilterPattern")
+                .onCall(0)
+                .returns(fakeData.excludeFilter)
+                .onCall(1)
+                .returns(fakeData.includeFilter);
+            sandbox.stub(ccc, "jacocoGradleMultiModuleEnable").returns('Multi-Module Configuration');
+            sandbox.stub(ccc, "jacocoGradleSingleModuleEnable").returns('Single-MOdule Configuration');
+            appendTextToFileSync = sandbox.stub(util, "appendTextToFileSync").callsFake();
+        });
+    
+        after(() => {
+            sandbox.restore();
+        });
+
+        afterEach(() => {
+            sandbox.resetHistory();
+        })
+
+        it('should call \'jacocoGradleMultiModuleEnable\' if project is multi-module', async () => {
+            const actual = await jacocoGradleCodeCoverageEnablerInstance.enableCodeCoverage(
+                {
+                    buildfile: fakeData.buildFile,
+                    classfilter: fakeData.classFilter,
+                    classfilesdirectories: fakeData.classDir,
+                    summaryfile: fakeData.summaryFile,
+                    reportdirectory: fakeData.reportDir,
+                    ismultimodule: 'true',
+                    gradle5xOrHigher: 'true'
+                });
+            sandbox.assert.calledOnce(ccc.jacocoGradleMultiModuleEnable);
+            assert.strictEqual(actual, true);
+        });
+
+        it('should call \'jacocoGradleSingleModuleEnable\' if project is single-module', async () => {
+            const actual = await jacocoGradleCodeCoverageEnablerInstance.enableCodeCoverage(
+                {
+                    buildfile: fakeData.buildFile,
+                    classfilter: fakeData.classFilter,
+                    classfilesdirectories: fakeData.classDir,
+                    summaryfile: fakeData.summaryFile,
+                    reportdirectory: fakeData.reportDir,
+                    ismultimodule: 'false',
+                    gradle5xOrHigher: 'true'
+                });
+            sandbox.assert.calledOnce(ccc.jacocoGradleSingleModuleEnable);
+            assert.strictEqual(actual, true);
+        });
+
+        it('should write warning and reject promise in case of error', async () => {
+            appendTextToFileSync.callsFake(() => { throw new Error('Some error has occurred') });
+            assert.rejects(jacocoGradleCodeCoverageEnablerInstance.enableCodeCoverage(
+                {
+                    buildfile: fakeData.buildFile,
+                    classfilter: fakeData.classFilter,
+                    classfilesdirectories: fakeData.classDir,
+                    summaryfile: fakeData.summaryFile,
+                    reportdirectory: fakeData.reportDir,
+                    ismultimodule: 'false',
+                    gradle5xOrHigher: 'true'
+                }), Error)
+            sandbox.assert.calledOnce(tl.warning);
+            appendTextToFileSync.callsFake();
+        });
+    })
+}

--- a/Tests/jacocogradleccenablerTests.ts
+++ b/Tests/jacocogradleccenablerTests.ts
@@ -81,7 +81,7 @@ export function jacocogradleccenablerTests() {
                     gradle5xOrHigher: 'true'
                 });
             sandbox.assert.calledOnce(ccc.jacocoGradleMultiModuleEnable);
-            assert.strictEqual(actual, true);
+            assert.strictEqual(actual, '');
         });
 
         it('should call \'jacocoGradleSingleModuleEnable\' if project is single-module', async () => {
@@ -96,7 +96,7 @@ export function jacocogradleccenablerTests() {
                     gradle5xOrHigher: 'true'
                 });
             sandbox.assert.calledOnce(ccc.jacocoGradleSingleModuleEnable);
-            assert.strictEqual(actual, true);
+            assert.strictEqual(actual, '');
         });
 
         it('should write warning and reject promise in case of error', async () => {

--- a/Tests/jacocomavenccenablerTests.ts
+++ b/Tests/jacocomavenccenablerTests.ts
@@ -1,0 +1,244 @@
+import * as assert from 'assert';
+import * as ccc from "../codecoverageconstants";
+import * as expectedResults from "./data/expectedResults";
+import * as fakeData from "./data/fakeData"
+import * as Q from "q";
+import * as rewire from 'rewire';
+import * as sinon from 'sinon';
+import * as tl from 'azure-pipelines-task-lib/task';
+import * as util from "../utilities";
+
+export function jacocomavenccenablerTests() {
+    const sandbox = sinon.createSandbox();
+    const jacocomavenenablerRewired = rewire('../jacoco/jacoco.maven.ccenabler');
+    const jacocoMavenCodeCoverageEnablerClass = jacocomavenenablerRewired.__get__('JacocoMavenCodeCoverageEnabler')
+    const jacocoMavenCodeCoverageEnablerInstance = new jacocoMavenCodeCoverageEnablerClass();
+    
+    before(() => {
+        jacocoMavenCodeCoverageEnablerInstance.classDirs = null;
+        jacocoMavenCodeCoverageEnablerInstance.excludeFilter = null;
+        jacocoMavenCodeCoverageEnablerInstance.includeFilter = null;
+        jacocoMavenCodeCoverageEnablerInstance.reportBuildFile = null;
+        jacocoMavenCodeCoverageEnablerInstance.reportDir = null;
+        jacocoMavenCodeCoverageEnablerInstance.sourceDirs = null;
+    });
+    
+    after(() => {
+        sandbox.restore();
+    });
+    
+    describe('function enableCodeCoverage', () => {
+        let extractFiltersStub, applyFilterPatternStub, readXmlFileAsJsonStub;
+        
+        before(() => {
+            sandbox.stub(tl, 'debug').callsFake();
+            extractFiltersStub = sandbox.stub(jacocoMavenCodeCoverageEnablerInstance, 'extractFilters').callsFake(function () { return fakeData.filters });
+            applyFilterPatternStub = sandbox.stub(jacocoMavenCodeCoverageEnablerInstance, 'applyFilterPattern').callsFake();
+            sandbox.stub(jacocoMavenCodeCoverageEnablerInstance, 'addCodeCoverageData').returns(Q.resolve());
+            readXmlFileAsJsonStub = sandbox.stub(util, 'readXmlFileAsJson').returns(Q.resolve());
+        });
+        
+        afterEach(() => {
+            extractFiltersStub.resetHistory();
+            applyFilterPatternStub.resetHistory();
+            readXmlFileAsJsonStub.resetHistory();
+        });
+        
+        after(() => {
+            sandbox.restore();
+        });
+        
+        it('should call correct functions', async () => {
+            await jacocoMavenCodeCoverageEnablerInstance.enableCodeCoverage({
+                buildfile: fakeData.buildFile,
+                reportdirectory: fakeData.reportDir,
+                sourcedirectories: fakeData.sourceDirs,
+                classfilesdirectories: fakeData.classDirs,
+                reportbuildfile: fakeData.reportBuildFile,
+                classfilter: fakeData.classFilter,
+            });
+            sinon.assert.calledOnceWithExactly(extractFiltersStub, fakeData.classFilter);
+            sinon.assert.calledWithExactly(applyFilterPatternStub, fakeData.filters.includeFilter);
+            sinon.assert.calledWithExactly(applyFilterPatternStub, fakeData.filters.excludeFilter);
+            sinon.assert.calledOnceWithExactly(readXmlFileAsJsonStub, fakeData.buildFile);
+        });
+    });
+    
+    describe('function applyFilterPattern', () => {
+        let isNullOrWhitespaceStub;
+
+        before(() => {
+            sandbox.stub(tl, 'debug');
+            sandbox.stub(util, "trimToEmptyString").callsFake((value) => value);
+            isNullOrWhitespaceStub = sandbox.stub(util, "isNullOrWhitespace").callsFake();
+        });
+    
+        after(() => {
+            sandbox.restore();
+        });
+
+        afterEach(() => {
+            isNullOrWhitespaceStub.reset();
+        })
+
+        it('should return empty array if filter is empty', () => {
+            isNullOrWhitespaceStub.returns(true);
+            const actual = jacocoMavenCodeCoverageEnablerInstance.applyFilterPattern("");
+            assert.deepStrictEqual(actual, []);
+        });
+    
+        it('should return correct array of filters', () => {
+            isNullOrWhitespaceStub.returns(false);
+            const actual = jacocoMavenCodeCoverageEnablerInstance.applyFilterPattern(fakeData.filtersWithNotAppliedFilterPattern);
+            assert.deepStrictEqual(actual, expectedResults.jacocoMavenCorrectedAppliedFilterPatter);
+        });
+    });
+    
+    describe('function addCodeCoverageData', () => {
+        before(() => {
+            sandbox.stub(tl, 'debug');
+            sandbox.stub(tl, 'loc');
+            sandbox.stub(jacocoMavenCodeCoverageEnablerInstance, 'addCodeCoveragePluginData').resolves("addCodeCoveragePluginData");
+            sandbox.stub(jacocoMavenCodeCoverageEnablerInstance, 'createMultiModuleReport').resolves("createMultiModuleReport");
+        });
+        
+        after(() => {
+            sandbox.restore();
+        });
+        
+        it('should reject if there is no project node in build configuration', () => {
+            assert.rejects(jacocoMavenCodeCoverageEnablerInstance.addCodeCoverageData(fakeData.addCodeCoverageDataPomJsonWithoutProject));
+        });
+        
+        it('should return correct value if project is single-module', async () => {
+            const actual = await jacocoMavenCodeCoverageEnablerInstance.addCodeCoverageData(fakeData.addCodeCoverageDataPomJsonSingle);
+            assert.deepStrictEqual(actual, expectedResults.addCodeCoverageDataSingleProject);
+        });
+        
+        it('should return correct value if project is multi-module', async () => {
+            const actual = await jacocoMavenCodeCoverageEnablerInstance.addCodeCoverageData(fakeData.addCodeCoverageDataPomJsonMulti);
+            assert.deepStrictEqual(actual, expectedResults.addCodeCoverageDataMultiProject);
+        });
+    });
+    
+    describe('function getBuildDataNode', () => {
+        it('should return correct build node and correct build configuration if build node is string', () => {
+            const config = fakeData.getBuildDataNodeBuildJsonContentBuildString();
+            const actual = jacocoMavenCodeCoverageEnablerInstance.getBuildDataNode(config);
+            assert.deepStrictEqual(actual, expectedResults.getBuildDataNodeBuildString);
+            assert.deepStrictEqual(config, expectedResults.getBuildDataNodeBuildJsonContentBuildString);
+        });
+        
+        it('should return correct build node if build node is array', () => {
+            const config = fakeData.getBuildDataNodeBuildJsonContentBuildArray();
+            const actual = jacocoMavenCodeCoverageEnablerInstance.getBuildDataNode(config);
+            assert.deepStrictEqual(actual, expectedResults.getBuildDataNodeBuildArray);
+            assert.deepStrictEqual(config, expectedResults.getBuildDataNodeBuildJsonContentBuildArray);
+        });
+        
+        it('should return correct build node and correct build configuration if build node is array with string element', () => {
+            const config = fakeData.getBuildDataNodeBuildJsonContentBuildArrayWithStringElement();
+            const actual = jacocoMavenCodeCoverageEnablerInstance.getBuildDataNode(config);
+            assert.deepStrictEqual(actual, expectedResults.getBuildDataNodeBuildArrayWithStringElement);
+            assert.deepStrictEqual(config, expectedResults.getBuildDataNodeBuildJsonContentBuildArrayWithStringElement);
+        });
+    });
+    
+    describe('function getPluginDataNode ', () => {
+        it('should return correct plugin data node if there is no plugin data node', () => {
+            const config = fakeData.getPluginDataNodeWithoutPluginsNode();
+            const actual = jacocoMavenCodeCoverageEnablerInstance.getPluginDataNode(config);
+            assert.deepStrictEqual(actual, expectedResults.getPluginDataNodeWithoutPluginsNode);
+            assert.deepStrictEqual(config, expectedResults.getPluginDataNodeWithoutPluginsNodeConfig);
+        });
+        
+        it('should return correct plugin data node if there is plugin node with string value', () => {
+            const config = fakeData.getPluginDataNodePluginsString();
+            const actual = jacocoMavenCodeCoverageEnablerInstance.getPluginDataNode(config);
+            assert.deepStrictEqual(actual, expectedResults.getPluginDataNodePluginsString);
+            assert.deepStrictEqual(config, expectedResults.getPluginDataNodePluginsStringConfig);
+        });
+        
+        it('should return correct plugin data node if there is plugin node with string array', () => {
+            const config = fakeData.getPluginDataNodePluginsStringArray();
+            const actual = jacocoMavenCodeCoverageEnablerInstance.getPluginDataNode(config);
+            assert.deepStrictEqual(actual, expectedResults.getPluginDataNodePluginsStringArray);
+            assert.deepStrictEqual(config, expectedResults.getPluginDataNodePluginsStringArrayConfig);
+        });
+        
+        it('should return correct plugin data node if there is plugin node with array', () => {
+            const config = fakeData.getPluginDataNodePluginsArray();
+            const actual = jacocoMavenCodeCoverageEnablerInstance.getPluginDataNode(config);
+            assert.deepStrictEqual(actual, expectedResults.getPluginDataNodePluginsArray);
+            assert.deepStrictEqual(config, expectedResults.getPluginDataNodePluginsArrayConfig);
+        });
+        
+        it('should return correct plugin data node if there is plugin node contains object', () => {
+            const config = fakeData.getPluginDataNodePluginsAnother();
+            const actual = jacocoMavenCodeCoverageEnablerInstance.getPluginDataNode(config);
+            assert.deepStrictEqual(actual, expectedResults.getPluginDataNodePluginsAnother);
+            assert.deepStrictEqual(config, expectedResults.getPluginDataNodePluginsAnotherConfig);
+        });
+    });
+    
+    describe('function createMultiModuleReport', () => {
+        let sourceDirsStub, classDirsStub, includeFilterStub, excludeFilterStub, isNullOrWhitespaceStub, jacocoMavenMultiModuleReportStub;
+        
+        before(() => {
+            sourceDirsStub = sandbox.stub(jacocoMavenCodeCoverageEnablerInstance, 'sourceDirs');
+            classDirsStub = sandbox.stub(jacocoMavenCodeCoverageEnablerInstance, 'classDirs');
+            includeFilterStub = sandbox.stub(jacocoMavenCodeCoverageEnablerInstance, 'includeFilter');
+            excludeFilterStub = sandbox.stub(jacocoMavenCodeCoverageEnablerInstance, 'excludeFilter');
+            isNullOrWhitespaceStub = sandbox.stub(util, 'isNullOrWhitespace');
+            sandbox.stub(util, 'writeFile').resolves();
+            jacocoMavenMultiModuleReportStub = sandbox.stub(ccc, 'jacocoMavenMultiModuleReport').resolves();
+        });
+        
+        afterEach(() => {
+            sourceDirsStub.restore();
+            classDirsStub.restore();
+            includeFilterStub.restore();
+            excludeFilterStub.restore();
+            isNullOrWhitespaceStub.reset();
+            jacocoMavenMultiModuleReportStub.resetHistory();
+        });
+        
+        after(() => {
+            sandbox.restore();
+        });
+        
+        it('should join filters and set srcDirs and classDirs if they are null', async () => {
+            isNullOrWhitespaceStub.returns(true);
+            includeFilterStub.value(fakeData.includeFilter);
+            excludeFilterStub.value(fakeData.excludeFilter);
+            sourceDirsStub.value(fakeData.sourceDir);
+            classDirsStub.value(fakeData.classDir);
+            await jacocoMavenCodeCoverageEnablerInstance.createMultiModuleReport(fakeData.reportDir);
+            sinon.assert.calledOnceWithExactly(
+                jacocoMavenMultiModuleReportStub,
+                fakeData.reportDir,
+                ".",
+                ".",
+                fakeData.includeFilterStringifiedWithComma,
+                fakeData.excludeFilterStringifiedWithComma
+            );
+        });
+        
+        it('should join filters and shouldn\'t set srcDirs and classDirs if they are not null', async () => {
+            isNullOrWhitespaceStub.returns(false);
+            includeFilterStub.value(fakeData.includeFilter);
+            excludeFilterStub.value(fakeData.excludeFilter);
+            sourceDirsStub.value(fakeData.sourceDir);
+            classDirsStub.value(fakeData.classDir);
+            await jacocoMavenCodeCoverageEnablerInstance.createMultiModuleReport(fakeData.reportDir);
+            sinon.assert.calledOnceWithExactly(
+                jacocoMavenMultiModuleReportStub,
+                fakeData.reportDir,
+                fakeData.sourceDir,
+                fakeData.classDir,
+                fakeData.includeFilterStringifiedWithComma,
+                fakeData.excludeFilterStringifiedWithComma
+            );
+        });
+    });
+}

--- a/Tests/utilitiesTests.ts
+++ b/Tests/utilitiesTests.ts
@@ -1,0 +1,141 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as tl from 'azure-pipelines-task-lib/task'
+import * as utilities from '../utilities';
+
+import * as expectedResults from './data/expectedResults';
+import * as fakeData from './data/fakeData';
+
+export function utilitiesTests() {
+    const sandbox = sinon.createSandbox();
+    
+    before(() => {
+        sandbox.stub(tl, "debug").callsFake();
+    })
+
+    after(() => {
+        sandbox.restore();
+    });
+
+    it('function sharedSubString should return empty string if there is no common substring', () => {
+        const actual = utilities.sharedSubString(fakeData.sharedSubString1, fakeData.sharedSubString2)
+        assert.strictEqual(actual, "");
+    });
+
+    it('function sharedSubString should common substring', () => {
+        const actual = utilities.sharedSubString(fakeData.sharedSubString1, fakeData.sharedSubString3)
+        assert.strictEqual(actual, "ab");
+    });
+
+    it('function sortStringArray should sort string in ascending order', () => {
+        const actual = utilities.sortStringArray(fakeData.stringArray);
+        assert.deepStrictEqual(actual, expectedResults.sortedStringArray); 
+    });
+
+    it('function sortStringArray should sort string in ascending order', () => {
+        const actual = utilities.sortStringArray(fakeData.stringArray);
+        assert.deepStrictEqual(actual, expectedResults.sortedStringArray); 
+    });
+
+    it('function isNullOrWhitespace should return true if specified string is null', () => {
+        const actual = utilities.isNullOrWhitespace(null);
+        assert.strictEqual(actual, true);
+    });
+
+    it('function isNullOrWhitespace should return true if specified string is whitespace', () => {
+        const actual = utilities.isNullOrWhitespace("    ");
+        assert.strictEqual(actual, true);
+    });
+
+    it('function isNullOrWhitespace should return false if specified string is not null or whitespace', () => {
+        const actual = utilities.isNullOrWhitespace("fake string");
+        assert.strictEqual(actual, false);
+    });
+
+    it('function trimToEmptyString should return empty string if specified string is null', () => {
+        const actual = utilities.trimToEmptyString(null);
+        assert.strictEqual(actual, "");
+    });
+
+    it('function trimToEmptyString should return trimmed string', () => {
+        const actual = utilities.trimToEmptyString(" fake string ");
+        assert.strictEqual(actual, fakeData.string);
+    });
+
+    it('function trimEnd should return specified string if specified trim char is null', () => {
+        const actual = utilities.trimEnd(fakeData.string, null);
+        assert.strictEqual(actual, fakeData.string);
+    });
+
+    it('function trimEnd should return null if specified string is null', () => {
+        const actual = utilities.trimEnd(null, "q");
+        assert.strictEqual(actual, null);
+    });
+
+    it('function trimEnd should return string without specified char at the end', () => {
+        const actual = utilities.trimEnd(fakeData.string, "g");
+        assert.strictEqual(actual, "fake strin");
+    });
+
+    it('function trimEnd should return specified string if there is no specified trim char at the end', () => {
+        const actual = utilities.trimEnd(fakeData.string, "r");
+        assert.strictEqual(actual, fakeData.string);
+    });
+
+    it('function addPropToJson should return object with added property', () => {
+        const jsonObj = {
+            firstProperty: "First Value",
+            secondProperty: "Second Value"
+        }
+        utilities.addPropToJson(jsonObj, fakeData.propertyName, fakeData.propertyValue);
+        assert.deepStrictEqual(jsonObj, expectedResults.objectWithAddedProperty);
+    });
+
+    it('function addPropToJson should convert property to array and add specified value if property already exist', () => {
+        const jsonObj = {
+            firstProperty: "First Value",
+            secondProperty: "Second Value",
+            someProperty: 42
+        }
+        utilities.addPropToJson(jsonObj, fakeData.propertyName, fakeData.propertyValue);
+        assert.deepStrictEqual(jsonObj, expectedResults.objectWithAddedPropertyIntoArray);
+    });
+
+    it('function addPropToJson should push specified value if specified property already exist as array', () => {
+        const jsonObj = {
+            firstProperty: "First Value",
+            secondProperty: "Second Value",
+            someProperty: [42]
+        }
+        utilities.addPropToJson(jsonObj, fakeData.propertyName, fakeData.propertyValue);
+        assert.deepStrictEqual(jsonObj, expectedResults.objectWithAddedPropertyIntoArray);
+    });
+
+    it('function addPropToJson should add property in new element of array if it\'s specified as parameter', () => {
+        const jsonObj = [
+            {
+                firstProperty: "First Value",
+                secondProperty: "Second Value"
+            },
+            {
+                firstProperty: "First Value",
+            }
+        ]
+        utilities.addPropToJson(jsonObj, fakeData.propertyName, fakeData.propertyValue);
+        assert.deepStrictEqual(jsonObj, expectedResults.arrayWithAddedProperty);
+    });
+
+    it('function addPropToJson should add append specified value to specified property if it\'s in array element', () => {
+        const jsonObj = [
+            {
+                firstProperty: "First Value",
+            },
+            {
+                firstProperty: "First Value",
+                someProperty: 42
+            }
+        ]
+        utilities.addPropToJson(jsonObj, fakeData.propertyName, fakeData.propertyValue);
+        assert.deepStrictEqual(jsonObj, expectedResults.arrayWithAppendedProperty);
+    });
+}

--- a/cobertura/cobertura.ant.ccenabler.ts
+++ b/cobertura/cobertura.ant.ccenabler.ts
@@ -71,7 +71,7 @@ export class CoberturaAntCodeCoverageEnabler extends cc.CoberturaCodeCoverageEna
             classDirs = ".";
         }
         classDirs.split(",").forEach(cdir => {
-            classData += classData + `
+            classData = classData + `
             <fileset dir="${cdir}" includes="${_this.includeFilter}" excludes="${_this.excludeFilter}" />
             `;
         });

--- a/jacoco/jacoco.maven.ccenabler.ts
+++ b/jacoco/jacoco.maven.ccenabler.ts
@@ -69,7 +69,7 @@ export class JacocoMavenCodeCoverageEnabler extends cc.JacocoCodeCoverageEnabler
         let _this = this;
 
         if (!pomJson.project) {
-            Q.reject(tl.loc("InvalidBuildFile"));
+            return Q.reject(tl.loc("InvalidBuildFile"));
         }
 
         let isMultiModule = false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,161 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "requires": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g=="
+    },
+    "@babel/highlight": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@eslint/eslintrc": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^13.9.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
+    },
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ=="
+    },
     "@types/cheerio": {
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.0.tgz",
@@ -25,6 +180,12 @@
         "@types/node": "*"
       }
     },
+    "@types/mocha": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+      "dev": true
+    },
     "@types/node": {
       "version": "10.17.48",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.48.tgz",
@@ -40,10 +201,73 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
       "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ=="
     },
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
+    },
+    "acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -69,6 +293,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+    },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -83,15 +312,57 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+    },
+    "camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "cheerio": {
       "version": "1.0.0-rc.6",
@@ -117,6 +388,44 @@
         "domhandler": "^4.2.0",
         "domutils": "^2.7.0"
       }
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -147,6 +456,16 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
     "css-select": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.2.1.tgz",
@@ -164,10 +483,48 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
       "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw=="
     },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "requires": {
+        "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w=="
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "dom-serializer": {
       "version": "1.3.2",
@@ -202,10 +559,288 @@
         "domhandler": "^4.2.0"
       }
     },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
+    },
     "entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
+    "escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+    },
+    "eslint": {
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+      "requires": {
+        "@babel/code-frame": "7.12.11",
+        "@eslint/eslintrc": "^0.4.3",
+        "@humanwhocodes/config-array": "^0.5.0",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.1.2",
+        "globals": "^13.6.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^6.0.9",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
+    },
+    "espree": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "requires": {
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+        }
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+    },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "requires": {
+        "flat-cache": "^3.0.4"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "requires": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
+    },
+    "flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "flatted": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
     "form-data": {
       "version": "2.5.1",
@@ -234,10 +869,26 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g=="
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-port": {
       "version": "3.2.0",
@@ -257,6 +908,22 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globals": {
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "requires": {
+        "type-fest": "^0.20.2"
+      }
+    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -269,6 +936,16 @@
       "requires": {
         "function-bind": "^1.1.1"
       }
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "htmlparser2": {
       "version": "6.1.0",
@@ -300,6 +977,25 @@
         "@types/node": "^10.0.3"
       }
     },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -319,6 +1015,14 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
     "is-core-module": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
@@ -327,10 +1031,71 @@
         "has": "^1.0.3"
       }
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
     },
     "jsonfile": {
       "version": "2.4.0",
@@ -340,12 +1105,66 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
+    },
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "requires": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
+    "locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "requires": {
+        "p-locate": "^5.0.0"
+      }
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
+    },
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      }
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
       }
     },
     "mime-db": {
@@ -369,10 +1188,114 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "mocha": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
+      "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
+      "requires": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "5.0.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.3",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "workerpool": "6.2.1",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+              "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+              "requires": {
+                "balanced-match": "^1.0.0"
+              }
+            }
+          }
+        }
+      }
+    },
     "mockery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
+    },
+    "ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "nanoid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w=="
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+    },
+    "nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "nth-check": {
       "version": "2.0.1",
@@ -390,10 +1313,47 @@
         "wrappy": "1"
       }
     },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
     "os": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
       "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
+    },
+    "p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
+    "p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "requires": {
+        "p-limit": "^3.0.2"
+      }
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "requires": {
+        "callsites": "^3.0.0"
+      }
     },
     "parse-cache-control": {
       "version": "1.0.1",
@@ -413,20 +1373,60 @@
         "parse5": "^6.0.1"
       }
     },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+        }
+      }
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+    },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "promise": {
       "version": "8.1.0",
@@ -435,6 +1435,11 @@
       "requires": {
         "asap": "~2.0.6"
       }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
       "version": "1.5.1",
@@ -445,6 +1450,14 @@
       "version": "6.9.6",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
       "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
     },
     "readable-stream": {
       "version": "2.3.3",
@@ -460,6 +1473,14 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -467,6 +1488,21 @@
       "requires": {
         "resolve": "^1.1.6"
       }
+    },
+    "regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg=="
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "resolve": {
       "version": "1.21.0",
@@ -476,6 +1512,19 @@
         "is-core-module": "^2.8.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+    },
+    "rewire": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rewire/-/rewire-6.0.0.tgz",
+      "integrity": "sha512-7sZdz5dptqBCapJYocw9EcppLU62KMEqDLIILJnNET2iqzXHaQfaVP5SOJ06XvjX+dNIDJbzjw0ZWzrgDhtjYg==",
+      "requires": {
+        "eslint": "^7.32.0"
       }
     },
     "rimraf": {
@@ -501,6 +1550,27 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
+    "serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+    },
     "shelljs": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
@@ -511,6 +1581,54 @@
         "rechoir": "^0.6.2"
       }
     },
+    "sinon": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.0.tgz",
+      "integrity": "sha512-ugA6BFmE+WrJdh0owRZHToLd32Uw3Lxq6E6LtNRU+xTVBefx632h03Q7apXWRsRdZAJ41LB8aUfn2+O4jsDNMw==",
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.1.2",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
@@ -519,10 +1637,31 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+    },
+    "supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
     },
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
@@ -546,6 +1685,41 @@
       "requires": {
         "get-port": "^3.1.0"
       }
+    },
+    "table": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+      "requires": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
     "then-request": {
       "version": "6.0.2",
@@ -572,6 +1746,32 @@
         }
       }
     },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+    },
+    "type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -583,6 +1783,14 @@
       "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
       "dev": true
     },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -592,6 +1800,39 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
+    "v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+    },
+    "workerpool": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw=="
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -611,6 +1852,51 @@
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.6.tgz",
       "integrity": "sha1-fIJtjYb0eISwWHLL6dJ7Ab7VA/Y="
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
+    },
+    "yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "requires": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -390,18 +390,18 @@
       }
     },
     "chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
       "requires": {
-        "anymatch": "~3.1.2",
+        "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
-        "glob-parent": "~5.1.2",
+        "fsevents": "~2.3.1",
+        "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
+        "readdirp": "~3.5.0"
       }
     },
     "cliui": {
@@ -929,6 +929,11 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -1059,11 +1064,6 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
     },
-    "is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -1080,9 +1080,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -1151,12 +1151,11 @@
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
     },
     "log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
       "requires": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
+        "chalk": "^4.0.0"
       }
     },
     "lru-cache": {
@@ -1189,38 +1188,56 @@
       }
     },
     "mocha": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
-      "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
+      "integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.5.3",
-        "debug": "4.3.4",
+        "chokidar": "3.5.1",
+        "debug": "4.3.1",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
-        "glob": "7.2.0",
+        "glob": "7.1.6",
+        "growl": "1.10.5",
         "he": "1.2.0",
-        "js-yaml": "4.1.0",
-        "log-symbols": "4.1.0",
-        "minimatch": "5.0.1",
+        "js-yaml": "4.0.0",
+        "log-symbols": "4.0.0",
+        "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.3.3",
-        "serialize-javascript": "6.0.0",
+        "nanoid": "3.1.20",
+        "serialize-javascript": "5.0.1",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
-        "workerpool": "6.2.1",
+        "which": "2.0.2",
+        "wide-align": "1.1.3",
+        "workerpool": "6.1.0",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            }
+          }
+        },
         "glob": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -1228,34 +1245,6 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
-          },
-          "dependencies": {
-            "minimatch": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            }
-          }
-        },
-        "minimatch": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          },
-          "dependencies": {
-            "brace-expansion": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-              "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-              "requires": {
-                "balanced-match": "^1.0.0"
-              }
-            }
           }
         }
       }
@@ -1271,9 +1260,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "nanoid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w=="
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -1474,9 +1463,9 @@
       }
     },
     "readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -1551,9 +1540,9 @@
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
       "requires": {
         "randombytes": "^2.1.0"
       }
@@ -1814,15 +1803,52 @@
         "isexe": "^2.0.0"
       }
     },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w=="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "workerpool": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
-      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
+      "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg=="
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -14,11 +14,15 @@
     "azure-pipelines-task-lib": "^3.1.0",
     "cheerio": "1.0.0-rc.6",
     "fs-extra": "^0.30.0",
+    "mocha": "^10.0.0",
     "os": "^0.1.1",
+    "rewire": "^6.0.0",
+    "sinon": "^14.0.0",
     "strip-bom": "^3.0.0",
     "xml2js": "^0.4.17"
   },
   "devDependencies": {
+    "@types/mocha": "^5.2.6",
     "typescript": "4.0.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "azure-pipelines-task-lib": "^3.1.0",
     "cheerio": "1.0.0-rc.6",
     "fs-extra": "^0.30.0",
-    "mocha": "^10.0.0",
+    "mocha": "^8.4.0",
     "os": "^0.1.1",
     "rewire": "^6.0.0",
     "sinon": "^14.0.0",
@@ -26,7 +26,8 @@
     "typescript": "4.0.2"
   },
   "scripts": {
-    "build": "cd ./build-scripts && npm install && cd ../ && node make.js"
+    "build": "cd ./build-scripts && npm install && cd ../ && node make.js",
+    "test": "mocha _build/Tests/L0.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-codecoverage-tools",
-  "version": "3.210.0",
+  "version": "3.211.0",
   "author": "Microsoft Corporation",
   "description": "VSTS Tasks Code Coverage Tools",
   "license": "MIT",


### PR DESCRIPTION
**Description**: Need to add unit-tests for npm-package `codecoverage-tools`

Change log:
- added unit-tests
- corrected issue around appending class data in function `getClassData` 
- corrected issue in function `addCodeCoverageData`: it doesn't stop execution if there is no node `project` in specified config

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) Y

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
