### PR TITLE
Fixing the issue with pom packaging type module in jacoco

### DIFF
--- a/jacoco/jacoco.maven.ccenabler.ts
+++ b/jacoco/jacoco.maven.ccenabler.ts
@@ -12,6 +12,7 @@ interface IPomData {
     groupId: string;
     artifactId: string;
     version: string;
+    packaging?: string;
     modules?: [string];
 }
 
@@ -186,6 +187,7 @@ export class JacocoMavenCodeCoverageEnabler extends cc.JacocoCodeCoverageEnabler
                         <groupId>${current.groupId}</groupId>
                         <artifactId>${current.artifactId}</artifactId>
                         <version>${current.version}</version>
+                        <type>${current.packaging}</type>
                     </dependency>
                     `
         }, '');
@@ -205,11 +207,13 @@ export class JacocoMavenCodeCoverageEnabler extends cc.JacocoCodeCoverageEnabler
                 .then((content) => {
                     const jsonGroup = content.project?.groupId;
                     const jsonVersion = content.project?.version;
+                    const jsonPackaging = content.project?.packaging;
 
                     return {
                         artifactId: content.project.artifactId[0],
                         groupId: (jsonGroup && jsonGroup[0]) || data.groupId,
-                        version: (jsonVersion && jsonVersion[0]) || data.version
+                        version: (jsonVersion && jsonVersion[0]) || data.version,
+                        packaging: (jsonPackaging && jsonPackaging[0]) || "jar"
                     };
                 });
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-codecoverage-tools",
-  "version": "3.210.0",
+  "version": "3.214.0",
   "author": "Microsoft Corporation",
   "description": "VSTS Tasks Code Coverage Tools",
   "license": "MIT",


### PR DESCRIPTION
**Description**: 
The Maven task and jacoco.maven.ccenabler work like this:
Submodule reports are saved in associated directories using the "prepare agent" and "report" goals. Is created a special submodule for reports. This submodule's pom file contains the main pom file as a parent, the other submodules as dependencies, and the "report-aggregate" goal in the "verify" phase. An aggregated report is used as the final results.

But if a submodule is of type packaging pom the special submodule can not resolve it correctly because of submodule dependency doesn't have `type` tag.

Change log:
- added packaging type module handling

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** https://github.com/microsoft/azure-pipelines-tasks/issues/17118

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
